### PR TITLE
Add support for direct _fsm as well as direct_stat

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -539,7 +539,7 @@
 %% Bypass sidejob for stat updates - increases efficiency, but prevents rate
 %% limiting of statistic updates (current limit is 10K persec, but limit not
 %% applied to counter updates)
-{mapping, "direct_stats", "riak_kv.direct_stat", [
+{mapping, "direct_stats", "riak_kv.direct_stats", [
     {default, on},
     {datatype, flag}
 ]}.

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -535,10 +535,29 @@
 
 %% We left riak_kv.add_paths out on purpose.
 
+%% @doc Direct stat changes
+%% Bypass sidejob for stat updates - increases efficiency, but prevents rate
+%% limiting of stat updates
+{mapping, "direct_stat", "riak_kv.direct_stat", [
+    {default, on},
+    {datatype, flag},
+    hidden
+]}.
+
+%% @doc Direct stat changes
+%% Bypass sidejob for GET and PUT FSMs in creases efficiency but prevents rate
+%% limiting
+{mapping, "direct_fsm", "riak_kv.direct_fsm", [
+    {default, on},
+    {datatype, flag},
+    hidden
+]}.
+
 %% @doc The maximum number of concurrent requests of each type (get or
 %% put) that is allowed. Setting this value to infinite disables
 %% overload protection. The 'erlang.process_limit' should be at least
 %% 3 times more than this setting.
+%% Note that enabling direct_fsm will make this rate limit redundant
 %% @see erlang.process_limit
 {mapping, "max_concurrent_requests", "riak_kv.fsm_limit", [
   {default, 50000},

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -537,20 +537,19 @@
 
 %% @doc Direct stat changes
 %% Bypass sidejob for stat updates - increases efficiency, but prevents rate
-%% limiting of stat updates
-{mapping, "direct_stat", "riak_kv.direct_stat", [
+%% limiting of statistic updates (current limit is 10K persec, but limit not
+%% applied to counter updates)
+{mapping, "direct_stats", "riak_kv.direct_stat", [
     {default, on},
-    {datatype, flag},
-    hidden
+    {datatype, flag}
 ]}.
 
 %% @doc Direct stat changes
-%% Bypass sidejob for GET and PUT FSMs in creases efficiency but prevents rate
+%% Bypass sidejob for GET and PUT FSMs increases efficiency but prevents rate
 %% limiting
 {mapping, "direct_fsm", "riak_kv.direct_fsm", [
-    {default, on},
-    {datatype, flag},
-    hidden
+    {default, off},
+    {datatype, flag}
 ]}.
 
 %% @doc The maximum number of concurrent requests of each type (get or

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -53,16 +53,29 @@
 start(_Type, _StartArgs) ->
     riak_core_util:start_app_deps(riak_kv),
 
-    FSM_Limit = find_fsm_limit(),
+    case application:get_env(riak_kv, direct_fsm, false) of
+        true ->
+            GetFSMCRef = counters:new(1, [write_concurrency]),
+            PutFSMCRef = counters:new(1, [write_concurrency]),
+            application:set_env(riak_kv, get_fsm_active_counter, GetFSMCRef),
+            application:set_env(riak_kv, put_fsm_active_counter, PutFSMCRef),
+            ok;
+        false ->
+            FSM_Limit = find_fsm_limit(),
 
-    sidejob:new_resource(riak_kv_put_fsm_sj, sidejob_supervisor, FSM_Limit),
-    sidejob:new_resource(riak_kv_get_fsm_sj, sidejob_supervisor, FSM_Limit),
+            sidejob:new_resource(riak_kv_put_fsm_sj, sidejob_supervisor, FSM_Limit),
+            sidejob:new_resource(riak_kv_get_fsm_sj, sidejob_supervisor, FSM_Limit),
 
-    Base = [riak_core_stat:prefix(), riak_kv],
-    riak_kv_exometer_sidejob:new_entry(Base ++ [put_fsm, sidejob],
-				       riak_kv_put_fsm_sj, "node_put_fsm", []),
-    riak_kv_exometer_sidejob:new_entry(Base ++ [get_fsm, sidejob],
-                                       riak_kv_get_fsm_sj, "node_get_fsm", []),
+            Base = [riak_core_stat:prefix(), riak_kv],
+            riak_kv_exometer_sidejob:new_entry(
+                Base ++ [put_fsm, sidejob],
+                riak_kv_put_fsm_sj, "node_put_fsm", []
+            ),
+            riak_kv_exometer_sidejob:new_entry(
+                Base ++ [get_fsm, sidejob],
+                riak_kv_get_fsm_sj, "node_get_fsm", []
+            )
+    end,
 
     case app_helper:get_env(riak_kv, direct_stats, false) of
         true ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -28,6 +28,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -export([test_link/7, test_link/5]).
 -endif.
+
+-compile({nowarn_deprecated_function, 
+            [{gen_fsm, start, 3}]}).
+
 -export([start/6, start_link/6, start/4, start_link/4]).
 -export([init/1, handle_event/3, handle_sync_event/4,
          handle_info/3, terminate/3, code_change/4]).
@@ -84,7 +88,8 @@
                 request_type :: undefined | request_type(),
                 override_vnodes = [] :: list(),
                 return_tombstone = false :: boolean(),
-                expected_fetchclock = false :: false | vclock:vclock()
+                expected_fetchclock = false :: false | vclock:vclock(),
+                counter_ref = none :: none|counters:counters_ref()
                }).
 
 -include("riak_kv_dtrace.hrl").
@@ -120,14 +125,24 @@ start_link(ReqId,Bucket,Key,R,Timeout,From) ->
             options()) -> {ok, pid()} | {error, any()}.
 start(From, Bucket, Key, GetOptions) ->
     Args = [From, Bucket, Key, GetOptions],
-    case sidejob_supervisor:start_child(riak_kv_get_fsm_sj,
-                                        gen_fsm, start_link,
-                                        [?MODULE, Args, []]) of
-        {error, overload} ->
-            riak_kv_util:overload_reply(From),
-            {error, overload};
-        {ok, Pid} ->
-            {ok, Pid}
+    case application:get_env(riak_kv, direct_fsm, false) of
+        true ->
+            gen_fsm:start(?MODULE, Args, []);
+        false ->
+            Child =
+                sidejob_supervisor:start_child(
+                    riak_kv_get_fsm_sj,
+                    gen_fsm,
+                    start_link,
+                    [?MODULE, Args, []]
+                ),
+            case Child of
+                {error, overload} ->
+                    riak_kv_util:overload_reply(From),
+                    {error, overload};
+                {ok, Pid} ->
+                    {ok, Pid}
+            end
     end.
 
 %% Included for backward compatibility, in case someone is, say, passing around
@@ -177,11 +192,23 @@ init([From, queue_name, QueueName, Options0]) ->
 init([From, Bucket, Key, Options0]) ->
     StartNow = os:timestamp(),
     Options = proplists:unfold(Options0),
-    StateData = #state{from = From,
-                       options = Options,
-                       bkey = {Bucket, Key},
-                       timing = riak_kv_fsm_timing:add_timing(prepare, []),
-                       startnow = StartNow},
+    ActiveCounter =
+        case application:get_env(riak_kv, get_fsm_active_counter, none) of
+            none ->
+                none;
+            CRef ->
+                counters:add(CRef, 1, 1),
+                CRef
+        end,
+    StateData =
+        #state{
+            from = From,
+            options = Options,
+            bkey = {Bucket, Key},
+            timing = riak_kv_fsm_timing:add_timing(prepare, []),
+            counter_ref = ActiveCounter,
+            startnow = StartNow
+        },
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     case Trace of
         true ->
@@ -519,7 +546,13 @@ handle_info(_Info, _StateName, StateData) ->
     {stop,badmsg,StateData}.
 
 %% @private
-terminate(Reason, _StateName, _State) ->
+terminate(Reason, _StateName, State) ->
+    case State#state.counter_ref of
+        none ->
+            ok;
+        ActiveCounter ->
+            counters:sub(ActiveCounter, 1, 1)
+    end,
     Reason.
 
 %% @private

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -29,9 +29,16 @@
 -include_lib("riak_kv_vnode.hrl").
 -include("riak_kv_types.hrl").
 
--compile({nowarn_deprecated_function, 
-            [{gen_fsm, start_link, 3},
-                {gen_fsm, send_event, 2}]}).
+-compile(
+    {
+        nowarn_deprecated_function, 
+        [
+            {gen_fsm, start_link, 3},
+            {gen_fsm, start, 3},
+            {gen_fsm, send_event, 2}
+        ]
+    }
+).
 
 -behaviour(gen_fsm).
 -define(DEFAULT_OPTS, [{returnbody, false}, {update_last_modified, true}]).
@@ -133,7 +140,8 @@
                 trace = false :: boolean(), 
                 tracked_bucket=false :: boolean(), %% track per bucket stats
                 bad_coordinators = [] :: [atom()],
-                coordinator_timeout :: integer()
+                coordinator_timeout :: integer(),
+                counter_ref = none :: none|counters:counters_ref()
                }).
 
 -include("riak_kv_dtrace.hrl").
@@ -161,14 +169,24 @@ start_link(ReqId,RObj,W,DW,Timeout,ResultPid,Options) ->
 
 start(From, Object, PutOptions) ->
     Args = [From, Object, PutOptions],
-    case sidejob_supervisor:start_child(riak_kv_put_fsm_sj,
-                                        gen_fsm, start_link,
-                                        [?MODULE, Args, []]) of
-        {error, overload} ->
-            riak_kv_util:overload_reply(From),
-            {error, overload};
-        {ok, Pid} ->
-            {ok, Pid}
+    case application:get_env(riak_kv, direct_fsm, false) of
+        true ->
+            gen_fsm:start(?MODULE, Args, []);
+        false ->
+            Child =
+                sidejob_supervisor:start_child(
+                    riak_kv_put_fsm_sj,
+                    gen_fsm,
+                    start_link,
+                    [?MODULE, Args, []]
+                ),
+            case Child of
+                {error, overload} ->
+                    riak_kv_util:overload_reply(From),
+                    {error, overload};
+                {ok, Pid} ->
+                    {ok, Pid}
+            end
     end.
 
 %% Included for backward compatibility, in case someone is, say, passing around
@@ -267,13 +285,25 @@ init([From, RObj, Options0]) ->
     CoordTimeout = get_put_coordinator_failure_timeout(),
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     Options = proplists:unfold(Options0),
-    StateData = #state{from = From,
-                       robj = RObj,
-                       bkey = BKey,
-                       trace = Trace,
-                       options = Options,
-                       timing = riak_kv_fsm_timing:add_timing(prepare, []),
-                       coordinator_timeout=CoordTimeout},
+    ActiveCounter =
+        case application:get_env(riak_kv, put_fsm_active_counter, none) of
+            none ->
+                none;
+            CRef ->
+                counters:add(CRef, 1, 1),
+                CRef
+        end,
+    StateData =
+        #state{
+            from = From,
+            robj = RObj,
+            bkey = BKey,
+            trace = Trace,
+            options = Options,
+            timing = riak_kv_fsm_timing:add_timing(prepare, []),
+            coordinator_timeout=CoordTimeout,
+            counter_ref = ActiveCounter
+        },
     case Trace of
         true ->
             riak_core_dtrace:put_tag([Bucket, $,, Key]),
@@ -723,7 +753,13 @@ handle_info(_Info, _StateName, StateData) ->
     {stop,badmsg,StateData}.
 
 %% @private
-terminate(Reason, _StateName, _State) ->
+terminate(Reason, _StateName, State) ->
+    case State#state.counter_ref of
+        none ->
+            ok;
+        ActiveCounter ->
+            counters:sub(ActiveCounter, 1, 1)
+    end,
     Reason.
 
 %% @private

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -99,11 +99,21 @@ untrack_bucket(Bucket) when is_binary(Bucket) ->
 
 %% The current number of active get fsms in riak
 active_gets() ->
-    counter_value([?PFX, ?APP, node, gets, fsm, active]).
+    case application:get_env(riak_kv, get_fsm_active_counter, none) of
+        none ->
+            counter_value([?PFX, ?APP, node, gets, fsm, active]);
+        CRef ->
+            counters:get(CRef, 1)
+    end.
 
 %% The current number of active put fsms in riak
 active_puts() ->
-    counter_value([?PFX, ?APP, node, puts, fsm, active]).
+    case application:get_env(riak_kv, put_fsm_active_counter, none) of
+        none ->
+            counter_value([?PFX, ?APP, node, puts, fsm, active]);
+        CRef ->
+            counters:get(CRef, 1)
+    end.
 
 counter_value(Name) ->
     case exometer:get_value(Name, [value]) of

--- a/src/riak_kv_status.erl
+++ b/src/riak_kv_status.erl
@@ -83,13 +83,38 @@ are_indexes_fixed(riak_kv_multi_backend, {_Idx, [{backend_status,_,Status}]}) ->
     fixed_index_status(riak_kv_eleveldb_backend, Statuses).
 
 get_stats(web) ->
-    aliases()
-        ++ expand_disk_stats(riak_kv_stat_bc:disk_stats())
-        ++ riak_kv_stat_bc:app_stats();
+    expand_disk_stats(riak_kv_stat_bc:disk_stats())
+    ++ riak_kv_stat_bc:app_stats()
+    ++ fake_sidejob_stats()
+    ++ aliases();
 get_stats(console) ->
-    aliases()
-        ++ riak_kv_stat_bc:disk_stats()
-        ++ riak_kv_stat_bc:app_stats().
+    riak_kv_stat_bc:disk_stats()
+    ++ riak_kv_stat_bc:app_stats()
+    ++ fake_sidejob_stats()
+    ++ aliases().
+
+fake_sidejob_stats() ->
+    case application:get_env(riak_kv, direct_fsm, false) of
+        true ->
+            [
+                {node_get_fsm_active, riak_kv_stat:active_gets()},
+			    {node_get_fsm_active_60s, 0},
+			    {node_get_fsm_in_rate, 0},
+			    {node_get_fsm_out_rate, 0},
+			    {node_get_fsm_rejected, 0},
+			    {node_get_fsm_rejected_60s, 0},
+			    {node_get_fsm_rejected_total, 0},
+                {node_put_fsm_active, riak_kv_stat:active_puts()},
+			    {node_put_fsm_active_60s, 0},
+			    {node_put_fsm_in_rate, 0},
+			    {node_put_fsm_out_rate, 0},
+			    {node_put_fsm_rejected, 0},
+			    {node_put_fsm_rejected_60s, 0},
+			    {node_put_fsm_rejected_total, 0}
+            ];
+        false ->
+            []
+    end.
 
 
 aliases() ->

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -676,19 +676,23 @@ summarise_process_memory_by_initial_call(TopN) when is_list(TopN) ->
         )
     ).
 
-%% @doc profile_riak/1
-%% Run eprof for ProfileTime milliseconds.  Will have an impact, so normally
 %% best to restrict ProfileTime to 100ms.  May fail on systems under heavy load
 -spec profile_riak(pos_integer()) -> analyzed|failed.
 profile_riak(ProfileTime) ->
-    eprof:start(),
-    case eprof:start_profiling(erlang:processes()) of
+    profile_riak(ProfileTime, 8 * ProfileTime).
+profile_riak(ProfileTime, MinReportTime) ->
+    {ok, PS} = eprof:start(),
+    P0 = sets:from_list(erlang:processes(), [{version, 2}]),
+    timer:sleep(100),
+    P1 = sets:from_list(erlang:processes(), [{version, 2}]),
+    RootSet = sets:to_list(sets:intersection(P0, P1)) -- [PS],
+    case eprof:start_profiling(RootSet) of
         profiling ->
             timer:sleep(ProfileTime),
             case eprof:stop_profiling() of
                 profiling_stopped ->
                     eprof:analyze(
-                        total, [{filter, [{time, float(10 * ProfileTime)}]}]
+                        total, [{filter, [{time, float(MinReportTime)}]}]
                     ),
                     stopped = eprof:stop(),
                     analyzed;


### PR DESCRIPTION
The "direct_" configuration switches will bypass sidejob for stat updates and GET/PUT FSMs.  This should increase throughput in CPU-bound environments, but stops the rate-limiting of sidejob.

Creates dummy stats to replace sidejob stats.