### PR TITLE
Nhse 034 orkv.i57 fixcapability

### DIFF
--- a/include/riak_kv_capability.hrl
+++ b/include/riak_kv_capability.hrl
@@ -57,7 +57,7 @@
 % -define(CAP_VCLOCK_ENCODING,
 %     riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib)
 % ).
--define(CAP_VCLOCK_ENCODING, encode_raw).
+-define(CAP_VCLOCK_ENCODING, encode_zlib).
 % -define(CAP_HANDOFF_DATA_ENCODING,
 %     riak_core_capability:get({riak_kv, handoff_data_encoding}, encode_zlib)
 % ).

--- a/include/riak_kv_capability.hrl
+++ b/include/riak_kv_capability.hrl
@@ -20,8 +20,6 @@
 %%
 %% -------------------------------------------------------------------
 
--define(DEFAULT_RT, head).
-
 -define(CAP_VNODE_VCLOCKS, riak_core_capability:get({riak_kv, vnode_vclocks})).
 -define(CAP_RPC_VNODE_VCLOCKS(Node), 
     case rpc:call(Node, riak_core_capability, get, [{riak_kv, vnode_vclocks}]) of
@@ -39,38 +37,46 @@
     riak_core_capability:get({riak_kv, crdt}, [])
 ).
 
--define(CAP_2I_VERSION,
-    riak_core_capability:get({riak_kv, secondary_index_version}, v1)
-).
+% -define(CAP_2I_VERSION,
+%     riak_core_capability:get({riak_kv, secondary_index_version}, v1)
+% ).
+-define(CAP_2I_VERSION, v3).
 -define(CAP_KEYS_BACKPRESSURE,
     riak_core_capability:get({riak_kv, listkeys_backpressure}, false)
 ).
--define(CAP_INDEX_BACKPRESSURE,
-    riak_core_capability:get({riak_kv, index_backpressure}, false)
-).
+% -define(CAP_INDEX_BACKPRESSURE,
+%     riak_core_capability:get({riak_kv, index_backpressure}, false)
+% ).
+-define(CAP_INDEX_BACKPRESSURE, true).
 
--define(CAP_OBJECT_FORMAT,
-    riak_core_capability:get({riak_kv, object_format}, v0)
-).
--define(CAP_VCLOCK_ENCODING,
-    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib)
-).
--define(CAP_HANDOFF_DATA_ENCODING,
-    riak_core_capability:get({riak_kv, handoff_data_encoding}, encode_zlib)
-).
--define(CAP_OBJECT_HASH_VERSION,
-    riak_core_capability:get({riak_kv, object_hash_version}, legacy)
-).
+% -define(CAP_OBJECT_FORMAT,
+%     riak_core_capability:get({riak_kv, object_format}, v0)
+% ).
+-define(CAP_OBJECT_FORMAT, app_helper:get_env(riak_kv, object_format, v1)).
 
--define(CAP_GETREQUEST_TYPE,
-    riak_core_capability:get({riak_kv, get_request_type}, ?DEFAULT_RT)
-).
+% -define(CAP_VCLOCK_ENCODING,
+%     riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib)
+% ).
+-define(CAP_VCLOCK_ENCODING, encode_raw).
+% -define(CAP_HANDOFF_DATA_ENCODING,
+%     riak_core_capability:get({riak_kv, handoff_data_encoding}, encode_zlib)
+% ).
+-define(CAP_HANDOFF_DATA_ENCODING, encode_raw).
+% -define(CAP_OBJECT_HASH_VERSION,
+%     riak_core_capability:get({riak_kv, object_hash_version}, legacy)
+% ).
+-define(CAP_OBJECT_HASH_VERSION, 0).
+% -define(CAP_GETREQUEST_TYPE,
+%     riak_core_capability:get({riak_kv, get_request_type}, head)
+% ).
+-define(CAP_GETREQUEST_TYPE, head).
 -define(CAP_MAPRED_2I_PIPE,
     riak_core_capability:get({riak_kv, mapred_2i_pipe}, false)
 ).
--define(CAP_PUTFSM_ACK,
-    riak_core_capability:get({riak_kv, put_fsm_ack_execute}, disabled)
-).
+% -define(CAP_PUTFSM_ACK,
+%     riak_core_capability:get({riak_kv, put_fsm_ack_execute}, disabled)
+% ).
+-define(CAP_PUTFSM_ACK, enabled).
 -define(CAP_PUTFSM_SOFTLIMIT,
     riak_core_capability:get({riak_kv, put_soft_limit}, false)
 ).

--- a/include/riak_kv_capability.hrl
+++ b/include/riak_kv_capability.hrl
@@ -1,0 +1,84 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_capability: fixing the setting of previously variable capabilities
+%%
+%% Copyright (c) 2007-2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-define(DEFAULT_RT, head).
+
+-define(CAP_VNODE_VCLOCKS, riak_core_capability:get({riak_kv, vnode_vclocks})).
+-define(CAP_RPC_VNODE_VCLOCKS(Node), 
+    case rpc:call(Node, riak_core_capability, get, [{riak_kv, vnode_vclocks}]) of
+        {badrpc, {'EXIT', {undef, _}}} ->
+            rpc:call(Node, app_helper, get_env, [riak_kv, vnode_vclocks, false]);
+        Result ->
+            Result
+    end
+).
+
+-define(CAP_CRDT_EPOCH,
+    riak_core_capability:get({riak_kv, crdt_epoch_versions}, ?E1_DATATYPE_VERSIONS)
+).
+-define(CAP_CRDT_TYPES,
+    riak_core_capability:get({riak_kv, crdt}, [])
+).
+
+-define(CAP_2I_VERSION,
+    riak_core_capability:get({riak_kv, secondary_index_version}, v1)
+).
+-define(CAP_KEYS_BACKPRESSURE,
+    riak_core_capability:get({riak_kv, listkeys_backpressure}, false)
+).
+-define(CAP_INDEX_BACKPRESSURE,
+    riak_core_capability:get({riak_kv, index_backpressure}, false)
+).
+
+-define(CAP_OBJECT_FORMAT,
+    riak_core_capability:get({riak_kv, object_format}, v0)
+).
+-define(CAP_VCLOCK_ENCODING,
+    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib)
+).
+-define(CAP_HANDOFF_DATA_ENCODING,
+    riak_core_capability:get({riak_kv, handoff_data_encoding}, encode_zlib)
+).
+-define(CAP_OBJECT_HASH_VERSION,
+    riak_core_capability:get({riak_kv, object_hash_version}, legacy)
+).
+
+-define(CAP_GETREQUEST_TYPE,
+    riak_core_capability:get({riak_kv, get_request_type}, ?DEFAULT_RT)
+).
+-define(CAP_MAPRED_2I_PIPE,
+    riak_core_capability:get({riak_kv, mapred_2i_pipe}, false)
+).
+-define(CAP_PUTFSM_ACK,
+    riak_core_capability:get({riak_kv, put_fsm_ack_execute}, disabled)
+).
+-define(CAP_PUTFSM_SOFTLIMIT,
+    riak_core_capability:get({riak_kv, put_soft_limit}, false)
+).
+
+-define(CAP_LEGACY_AAE,
+    riak_core_capability:get({riak_kv, anti_entropy}, disabled)
+).
+
+-define(CAP_TICTACAAE_REPAIRS,
+    riak_core_capability:get({riak_kv, tictacaae_prompted_repairs}, false)
+).

--- a/src/riak.erl
+++ b/src/riak.erl
@@ -30,6 +30,7 @@
 -export([code_hash/0]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("riak_kv_capability.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -106,7 +107,7 @@ client_connect(Node, ClientId= <<_:32>>) ->
             %% or the new vnode based vclocks should be used.
             %% N.B. all nodes must be upgraded to 1.0 before
             %% this can be enabled.
-            case vnode_vclocks(Node) of
+            case ?CAP_RPC_VNODE_VCLOCKS(Node) of
                 {badrpc, _Reason} ->
                     {error, {could_not_reach_node, Node}};
                 true ->
@@ -120,15 +121,6 @@ client_connect(Node, undefined) ->
 client_connect(Node, Other) ->
     client_connect(Node, <<(erlang:phash2(Other)):32>>).
 
-vnode_vclocks(Node) ->
-    case rpc:call(Node, riak_core_capability, get,
-                  [{riak_kv, vnode_vclocks}]) of
-        {badrpc, {'EXIT', {undef, _}}} ->
-            rpc:call(Node, app_helper, get_env,
-                     [riak_kv, vnode_vclocks, false]);
-        Result ->
-            Result
-    end.
 
 %%
 %% @doc Validate that a specified node is accessible and functional.

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -54,6 +54,8 @@
 -export([remove_node_from_coverage/0, reset_node_for_coverage/0]).
 -export([repair_node/0]).
 
+-include("riak_kv_capability.hrl").
+
 -compile({no_auto_import,[put/2]}).
 %% @type default_timeout() = 60000
 -define(DEFAULT_TIMEOUT, 60000).
@@ -127,13 +129,13 @@ maybe_update_consistent_stat(Node, Stat, Bucket, StartTS, Result) ->
     case node() of
         Node ->
             Duration = timer:now_diff(os:timestamp(), StartTS),
-            ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
-            ObjSize = case Result of
-                          {ok, Obj} ->
-                              riak_object:approximate_size(ObjFmt, Obj);
-                          _ ->
-                              undefined
-                      end,
+            ObjSize =
+                case Result of
+                    {ok, Obj} ->
+                        riak_object:approximate_size(?CAP_OBJECT_FORMAT, Obj);
+                    _ ->
+                        undefined
+                end,
             ok = riak_kv_stat:update({Stat, Bucket, Duration, ObjSize});
         _ ->
             ok

--- a/src/riak_index.erl
+++ b/src/riak_index.erl
@@ -51,6 +51,7 @@
 
 -include("riak_kv_wm_raw.hrl").
 -include("riak_kv_index.hrl").
+-include("riak_kv_capability.hrl").
 -define(TIMEOUT, 30000).
 -define(BUCKETFIELD, <<"$bucket">>).
 -define(KEYFIELD, <<"$key">>).
@@ -315,8 +316,7 @@ to_index_query(OldVersion, Args) ->
     end.
 
 to_index_query(Args) ->
-    Version = riak_core_capability:get({riak_kv, secondary_index_version}, v1),
-    to_index_query(Version, Args).
+    to_index_query(?CAP_2I_VERSION, Args).
 
 %% @doc upgrade a V1 Query to a v2 Query
 make_query({eq, ?BUCKETFIELD, _Bucket}, Q) ->

--- a/src/riak_kv_crdt.erl
+++ b/src/riak_kv_crdt.erl
@@ -39,6 +39,7 @@
 -include("riak_kv_wm_raw.hrl").
 -include("riak_object.hrl").
 -include_lib("riak_kv_types.hrl").
+-include("riak_kv_capability.hrl").
 
 -ifdef(TEST).
 -ifdef(EQC).
@@ -524,7 +525,7 @@ to_record(?GSET_TYPE, Val) ->
 
 %% @doc Check cluster capability for crdt support
 supported(Mod) ->
-    lists:member(Mod, riak_core_capability:get({riak_kv, crdt}, [])).
+    lists:member(Mod, ?CAP_CRDT_TYPES).
 
 %% @private get the binary version for a crdt mod, default to `1' for
 %% pre-versioned.
@@ -542,8 +543,7 @@ crdt_version(Mod) ->
             %% use any term except the integer `1' to unset app env
             %% and use capability negotiated CRDT version epoch.
             %% Default to 1 for any unknown CRDT version.
-            NegotiatedCap = riak_core_capability:get({riak_kv, crdt_epoch_versions}, ?E1_DATATYPE_VERSIONS),
-            proplists:get_value(Mod, NegotiatedCap, 1)
+            proplists:get_value(Mod, ?CAP_CRDT_EPOCH, 1)
     end.
 
 %% @doc turn a string token / atom into a

--- a/src/riak_kv_entropy_manager.erl
+++ b/src/riak_kv_entropy_manager.erl
@@ -61,6 +61,7 @@
          terminate/2, code_change/3]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("riak_kv_capability.hrl").
 
 -ifdef(TEST).
 -export([query_and_set_aae_throttle/1]).        % for eunit twiddle-testing
@@ -636,7 +637,7 @@ schedule_tick() ->
 maybe_tick(State) ->
     case enabled() of
         true ->
-            case riak_core_capability:get({riak_kv, anti_entropy}, disabled) of
+            case ?CAP_LEGACY_AAE of
                 disabled ->
                     NextState = State;
                 enabled_v1 ->
@@ -676,7 +677,7 @@ maybe_poke_tree(State) ->
 -spec maybe_start_upgrade(riak_core_ring(),state()) -> state().
 maybe_start_upgrade(Ring, State=#state{trees=Trees, version=legacy, pending_version=legacy}) ->
     Indices = riak_core_ring:my_indices(Ring),
-    case riak_core_capability:get({riak_kv, object_hash_version}, legacy) of
+    case ?CAP_OBJECT_HASH_VERSION of
         0 when length(Trees) == length(Indices) ->
             maybe_upgrade(State);
         _ ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -24,6 +24,7 @@
 -behaviour(gen_fsm).
 -include_lib("riak_kv_vnode.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include("riak_kv_capability.hrl").
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -export([test_link/7, test_link/5]).
@@ -92,7 +93,6 @@
 -define(DEFAULT_TIMEOUT, 60000).
 -define(DEFAULT_R, default).
 -define(DEFAULT_PR, default).
--define(DEFAULT_RT, head).
 -define(QUEUE_EMPTY_LOOPS, 8).
 
 %% ===================================================================
@@ -292,7 +292,7 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key},
                         UpNodes = riak_core_node_watcher:nodes(riak_kv),
                         riak_core_apl:get_apl_ann(DocIdx, N, UpNodes)
                 end,
-            RequestType = get_default_support_request_type(?DEFAULT_RT),
+            RequestType = ?CAP_GETREQUEST_TYPE,
             
             new_state_timeout(validate,
                                 StateData#state{
@@ -835,7 +835,7 @@ update_stats({ok, Obj}, #state{options=Options,
     %% Stat the number of siblings and the object size, and timings
     CRDTMod = get_option(crdt_op, Options),
     NumSiblings = riak_object:value_count(Obj),
-    ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
+    ObjFmt = ?CAP_OBJECT_FORMAT,
     ObjSize = riak_object:approximate_size(ObjFmt, Obj),
     Bucket = riak_object:bucket(Obj),
     ok = riak_kv_stat:update({get_fsm, Bucket, ResponseUSecs, Stages,
@@ -869,11 +869,6 @@ add_timing(Stage, State = #state{timing = Timing}) ->
 details() ->
     [timing,
      vnodes].
-
--spec get_default_support_request_type(Default::request_type()) -> request_type().
-get_default_support_request_type(Default) ->
-    Type = riak_core_capability:get({riak_kv, get_request_type}, Default),
-    Type.
 
 -ifdef(TEST).
 -define(expect_msg(Exp,Timeout),

--- a/src/riak_kv_index_fsm.erl
+++ b/src/riak_kv_index_fsm.erl
@@ -38,6 +38,7 @@
 -behaviour(riak_core_coverage_fsm).
 
 -include_lib("riak_kv_vnode.hrl").
+-include("riak_kv_capability.hrl").
 
 -define(SLOW_TIME, application:get_env(riak_kv, index_fsm_slow_timems, 200)).
 -define(FAST_TIME, application:get_env(riak_kv, index_fsm_fast_timems, 10)).
@@ -90,7 +91,7 @@
 %% environment.
 -spec use_ack_backpressure() -> boolean().
 use_ack_backpressure() ->
-    riak_core_capability:get({riak_kv, index_backpressure}, false) == true.
+    ?CAP_INDEX_BACKPRESSURE == true.
 
 %% @doc Construct the correct index command record.
 -spec req(binary(), term(), term()) -> term().

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -70,6 +70,7 @@
          handle_corrupted_object/4]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("riak_kv_capability.hrl").
 
 -type index() :: non_neg_integer().
 -type index_n() :: {index(), non_neg_integer()}.
@@ -547,7 +548,7 @@ check_upgrade_env() ->
 
 -spec get_cap_hash_version() -> version().
 get_cap_hash_version() ->
-    riak_core_capability:get({riak_kv, object_hash_version}, legacy).
+    ?CAP_OBJECT_HASH_VERSION.
 
 -spec find_version(list(), index()) -> version().
 find_version(Root, Index) ->

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -561,9 +561,11 @@ check_root_version(Root, Index, Version) when is_integer(Version) ->
             Version;
         false ->
             legacy
-    end;
-check_root_version(_Root, _Index, Version) ->
-    Version.
+    end
+%     ;
+% check_root_version(_Root, _Index, Version) ->
+%     Version
+    .
 
 %% @doc Init the trees.
 %%

--- a/src/riak_kv_index_hashtree.erl
+++ b/src/riak_kv_index_hashtree.erl
@@ -546,7 +546,7 @@ check_upgrade_env() ->
             false
     end.
 
--spec get_cap_hash_version() -> version().
+-spec get_cap_hash_version() -> 0.
 get_cap_hash_version() ->
     ?CAP_OBJECT_HASH_VERSION.
 
@@ -554,18 +554,14 @@ get_cap_hash_version() ->
 find_version(Root, Index) ->
     check_root_version(Root, Index, get_cap_hash_version()).
 
--spec check_root_version(list(), index(), version()) -> version().
+-spec check_root_version(list(), index(), 0) -> version().
 check_root_version(Root, Index, Version) when is_integer(Version) ->
     case filelib:is_dir(filename:join(filename:join(Root, "v" ++ integer_to_list(Version)),integer_to_list(Index))) of
         true ->
             Version;
         false ->
             legacy
-    end
-%     ;
-% check_root_version(_Root, _Index, Version) ->
-%     Version
-    .
+    end.
 
 %% @doc Init the trees.
 %%

--- a/src/riak_kv_keys_fsm.erl
+++ b/src/riak_kv_keys_fsm.erl
@@ -38,6 +38,7 @@
 -behaviour(riak_core_coverage_fsm).
 
 -include_lib("riak_kv_vnode.hrl").
+-include("riak_kv_capability.hrl").
 
 -export([init/2,
          process_results/2,
@@ -59,7 +60,7 @@
 %% environment.
 -spec use_ack_backpressure() -> boolean().
 use_ack_backpressure() ->
-    riak_core_capability:get({riak_kv, listkeys_backpressure}, false) == true.
+    ?CAP_KEYS_BACKPRESSURE == true.
 
 %% @doc Construct the correct listkeys command record.
 -spec req(binary(), term()) -> term().

--- a/src/riak_kv_mrc_pipe.erl
+++ b/src/riak_kv_mrc_pipe.erl
@@ -142,6 +142,7 @@
 -include_lib("riak_pipe/include/riak_pipe_log.hrl").
 -include("riak_kv_mrc_sink.hrl").
 -include("riak_kv_index.hrl").
+-include("riak_kv_capability.hrl").
 
 -export_type([map_query_fun/0,
               reduce_query_fun/0,
@@ -274,10 +275,11 @@ mapred_stream_sink({index, _Bucket, <<"$bucket">>, _Start, _End} = Inputs, Query
     %% Optimization exactly when folding whole bucket and using 2i:
     %% set return_body=true as csbucket does, and omit duplicate read
     %% from disk by riak_kv_pipe_listkeys and riak_kv_pipe_get.
-    Options = case riak_core_capability:get({riak_kv, mapred_2i_pipe}, false) of
-                  true -> [?USE_RETURN_BODY_TRUE];
-                  _ -> []
-              end,
+    Options =
+        case ?CAP_MAPRED_2I_PIPE of
+            true -> [?USE_RETURN_BODY_TRUE];
+            _ -> []
+        end,
     mapred_stream_sink(Inputs, Query, Options, Timeout);
 mapred_stream_sink(Inputs, Query, Timeout) ->
     mapred_stream_sink(Inputs, Query, [], Timeout).
@@ -622,7 +624,7 @@ send_inputs(Pipe, {Bucket, FilterExprs}, Timeout) ->
     end;
 send_inputs(Pipe, {index, Bucket, Index, Key}, Timeout) ->
     Query = {eq, Index, Key},
-    case riak_core_capability:get({riak_kv, mapred_2i_pipe}, false) of
+    case ?CAP_MAPRED_2I_PIPE of
         true ->
             riak_kv_pipe_index:queue_existing_pipe(
               Pipe, Bucket, Query, Timeout);
@@ -635,7 +637,7 @@ send_inputs(Pipe, {index, Bucket, Index, Key}, Timeout) ->
 
 send_inputs(Pipe, {index, Bucket, Index, StartKey, EndKey}, Timeout) ->
     Query = {range, Index, StartKey, EndKey},
-    case riak_core_capability:get({riak_kv, mapred_2i_pipe}, false) of
+    case ?CAP_MAPRED_2I_PIPE of
         true ->
             Query2 = case Index of
                         %% This head is special optimization to omit

--- a/src/riak_kv_pb_counter.erl
+++ b/src/riak_kv_pb_counter.erl
@@ -42,6 +42,7 @@
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 -include_lib("riak_pb/include/riak_pb_kv_codec.hrl").
 -include("riak_kv_types.hrl").
+-include("riak_kv_capability.hrl").
 
 -behaviour(riak_api_pb_service).
 
@@ -87,7 +88,7 @@ process(#rpbcountergetreq{bucket=B, key=K, r=R0, pr=PR0,
                             node_confirms=NC,
                             basic_quorum=BQ},
         #state{client=C} = State) ->
-    case lists:member(pncounter, riak_core_capability:get({riak_kv, crdt}, [])) of
+    case lists:member(pncounter, ?CAP_CRDT_TYPES) of
         true ->
             R = decode_quorum(R0),
             PR = decode_quorum(PR0),
@@ -113,7 +114,7 @@ process(#rpbcounterupdatereq{bucket=B, key=K,  w=W0, dw=DW0, pw=PW0,
                              amount=CounterOp,
                              returnvalue=RetVal},
         #state{client=C} = State) ->
-    case {allow_mult(B), lists:member(pncounter, riak_core_capability:get({riak_kv, crdt}, []))} of
+    case {allow_mult(B), lists:member(pncounter, ?CAP_CRDT_TYPES)} of
         {true, true} ->
             O = riak_kv_crdt:new(B, K, ?V1_COUNTER_TYPE),
 

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -53,6 +53,7 @@
 
 -include_lib("riak_pb/include/riak_kv_pb.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include("riak_kv_capability.hrl").
 
 
 -ifdef(TEST).
@@ -110,7 +111,7 @@ encode(Message) ->
 %% @doc process/2 callback. Handles an incoming request message.
 process(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
     ClientId =
-        case riak_core_capability:get({riak_kv, vnode_vclocks}) of
+        case ?CAP_VNODE_VCLOCKS of
             true ->
                 CID;
             false ->
@@ -120,12 +121,14 @@ process(rpbgetclientidreq, #state{client=C, client_id=CID} = State) ->
     {reply, Resp, State};
 
 process(#rpbsetclientidreq{client_id = ClientId}, State) ->
-    NewState = case riak_core_capability:get({riak_kv, vnode_vclocks}) of
-                   true -> State#state{client_id=ClientId};
-                   false ->
-                       {ok, C} = riak:local_client(ClientId),
-                       State#state{client = C}
-               end,
+    NewState =
+        case ?CAP_VNODE_VCLOCKS of
+            true ->
+                State#state{client_id=ClientId};
+            false ->
+                {ok, C} = riak:local_client(ClientId),
+                State#state{client = C}
+        end,
     {reply, rpbsetclientidresp, NewState};
 
 process(#rpbgetreq{bucket = <<>>}, State) ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -190,17 +190,16 @@ get_put_coordinator_failure_timeout() ->
 
 make_ack_options(Options) ->
     AckOption = get_option(ack_execute, Options),
-    AckCap = ?CAP_PUTFSM_ACK,
     RetryCoord =
         app_helper:get_env(riak_kv, retry_put_coordinator_failure, true) andalso
         get_option(retry_put_coordinator_failure, Options, true),
-    case {AckOption, AckCap, RetryCoord} of
+    case {AckOption, ?CAP_PUTFSM_ACK, RetryCoord} of
         {Pid, _, _} when is_pid(Pid) ->
             %% Some process (probably on another node) is already waiting
             %% for an ack, no need to monitor here.
             {false, Options};
-        {undefined, disabled, _} ->
-            {false, Options};
+        % {undefined, disabled, _} ->
+        %     {false, Options};
         {undefined, _, false} ->
             {false, Options};
         {undefined, enabled, true} ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -193,19 +193,15 @@ make_ack_options(Options) ->
     RetryCoord =
         app_helper:get_env(riak_kv, retry_put_coordinator_failure, true) andalso
         get_option(retry_put_coordinator_failure, Options, true),
-    case {AckOption, ?CAP_PUTFSM_ACK, RetryCoord} of
-        {Pid, _, _} when is_pid(Pid) ->
-            %% Some process (probably on another node) is already waiting
-            %% for an ack, no need to monitor here.
-            {false, Options};
-        % {undefined, disabled, _} ->
-        %     {false, Options};
-        {undefined, _, false} ->
-            {false, Options};
-        {undefined, enabled, true} ->
-            {true, [
-                %% ack forwarder
-                {ack_execute, self()}| Options]}
+    RequestAck =
+        RetryCoord andalso
+        ?CAP_PUTFSM_ACK == enabled andalso
+        not is_pid(AckOption),
+    case RequestAck of
+        true ->
+            {true, [{ack_execute, self()}| Options]};
+        false ->
+            {false, Options}
     end.
 
 spawn_coordinator_proc(CoordNode, Mod, Fun, Args) ->

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -28,6 +28,7 @@
 -endif.
 -include_lib("riak_kv_vnode.hrl").
 -include("riak_kv_types.hrl").
+-include("riak_kv_capability.hrl").
 
 -compile({nowarn_deprecated_function, 
             [{gen_fsm, start_link, 3},
@@ -189,7 +190,7 @@ get_put_coordinator_failure_timeout() ->
 
 make_ack_options(Options) ->
     AckOption = get_option(ack_execute, Options),
-    AckCap = riak_core_capability:get({riak_kv, put_fsm_ack_execute}, disabled),
+    AckCap = ?CAP_PUTFSM_ACK,
     RetryCoord =
         app_helper:get_env(riak_kv, retry_put_coordinator_failure, true) andalso
         get_option(retry_put_coordinator_failure, Options, true),
@@ -1298,7 +1299,7 @@ get_soft_limit_option(Options) ->
     %% The logic here is to be as safe as possible. If caps system is
     %% unavailble, then assume soft-limits are unsupported. If
     %% capability _is_ available AND supported, then the value will be true
-    SoftLimitSupported = riak_core_capability:get({riak_kv, put_soft_limit}, false),
+    SoftLimitSupported = ?CAP_PUTFSM_SOFTLIMIT,
     %% both the system (post forward) and the client (via options) can
     %% turn off soft-limit checking. However, by default, we should
     %% use them (if supported) - unless it is explicitly disabled by toggling the

--- a/src/riak_kv_tictacaae_repairs.erl
+++ b/src/riak_kv_tictacaae_repairs.erl
@@ -25,6 +25,7 @@
 -export([prompt_tictac_exchange/7, log_tictac_result/4, aae_loglevels/0]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("riak_kv_capability.hrl").
 
 -define(EXCHANGE_PAUSE_MS, 1000).
 -define(AAE_MAX_RESULTS, 128).
@@ -290,8 +291,7 @@ analyse_repairs(KeyClockList, MaxRepairs) ->
     RepairList = lists:foldl(fun analyse_repair/2, [], KeyClockList),
     EnableKeyRange =
         app_helper:get_env(riak_kv, tictacaae_enablekeyrange, false),
-    ClusterCapable =
-        riak_core_capability:get({riak_kv, tictacaae_prompted_repairs}, false),
+    ClusterCapable = ?CAP_TICTACAAE_REPAIRS,
     analyse_repairs(RepairList, MaxRepairs, EnableKeyRange, ClusterCapable).
 
 -spec analyse_repairs(repair_list(), non_neg_integer(), boolean(), boolean())

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -95,6 +95,7 @@
 -include_lib("riak_kv_map_phase.hrl").
 -include_lib("riak_core_pb.hrl").
 -include("riak_kv_types.hrl").
+-include("riak_kv_capability.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -2488,9 +2489,8 @@ encode_handoff_item({B, K}, V) ->
     %% before sending data to another node change binary version
     %% to one supported by the cluster. This way we don't send
     %% unsupported formats to old nodes
-    ObjFmt = riak_core_capability:get({riak_kv, object_format}, v0),
     try
-        Value  = riak_object:to_binary_version(ObjFmt, B, K, V),
+        Value  = riak_object:to_binary_version(?CAP_OBJECT_FORMAT, B, K, V),
         encode_binary_object(B, K, Value)
     catch Error:Reason ->
             ?LOG_WARNING("Handoff encode failed: ~p:~p",
@@ -4068,7 +4068,7 @@ object_info({Bucket, _Key}=BKey) ->
 %% Encoding and decoding selection:
 
 handoff_data_encoding_method() ->
-    riak_core_capability:get({riak_kv, handoff_data_encoding}, encode_zlib).
+    ?CAP_HANDOFF_DATA_ENCODING.
 
 %% Decode a binary object. Assumes data is in new format, legacy no longer 
 %% format supported
@@ -4177,7 +4177,7 @@ object_format(Mod, ModState) ->
         true ->
             v1;
         false ->
-            riak_core_capability:get({riak_kv, object_format}, v0)
+            ?CAP_OBJECT_FORMAT
     end.
 
 sanitize_bkey({{<<"default">>, B}, K}) ->

--- a/src/riak_kv_wm_counter.erl
+++ b/src/riak_kv_wm_counter.erl
@@ -68,8 +68,6 @@
 %%    </dl>
 %% Please see [http://docs.basho.com] for details of all the quorum values and there effect.
 
-
-
 -module(riak_kv_wm_counter).
 
 %% webmachine resource exports
@@ -114,7 +112,7 @@
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
 -include("riak_kv_types.hrl").
-
+-include("riak_kv_capability.hrl").
 
 -spec init(proplists:proplist()) -> {ok, context()}.
 %% @doc Initialize this resource.  This function extracts the
@@ -125,7 +123,7 @@ init(Props) ->
               riak=proplists:get_value(riak, Props)}}.
 
 service_available(RD, Ctx=#ctx{riak=RiakProps}) ->
-    case lists:member(pncounter, riak_core_capability:get({riak_kv, crdt}, [])) of
+    case lists:member(pncounter, ?CAP_CRDT_TYPES) of
         true ->
             case riak_kv_wm_utils:get_riak_client(RiakProps, riak_kv_wm_utils:get_client_id(RD)) of
                 {ok, C} ->

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -148,6 +148,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-include("riak_kv_capability.hrl").
+
 -define(API_VERSION, 1).
 -define(CAPABILITIES, [uses_r_object, async_fold]).
 
@@ -279,16 +281,15 @@ put(_Bucket, _PKey, _IndexSpecs, _Val, #state{op_put = Puts} = S) ->
     {ok, S#state{op_put = Puts + 1}}.
 
 put_object(Bucket, PKey, _IndexSpecs, RObj, #state{op_put = Puts} = S) ->
-    EncodedVal = case S#state.aae_mode of
-                     constant_binary ->
-                         S#state.constant_r_object;
-                     bkey ->
-                         term_to_binary(riak_object:new(Bucket, PKey, <<>>));
-                     r_object ->
-                         ObjFmt = riak_core_capability:get(
-                                    {riak_kv, object_format}, v0),
-                         riak_object:to_binary(ObjFmt, RObj)
-                 end,
+    EncodedVal =
+        case S#state.aae_mode of
+            constant_binary ->
+                S#state.constant_r_object;
+            bkey ->
+                term_to_binary(riak_object:new(Bucket, PKey, <<>>));
+            r_object ->
+                riak_object:to_binary(?CAP_OBJECT_FORMAT, RObj)
+        end,
     {{ok, S#state{op_put = Puts + 1}}, EncodedVal}.
 
 %% @doc Delete an object, yes, sir!

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -28,6 +28,7 @@
 -endif.
 -include("riak_kv_wm_raw.hrl").
 -include("riak_object.hrl").
+-include("riak_kv_capability.hrl").
 
 -export_type([riak_object/0, proxy_object/0, bucket/0, key/0, value/0, binary_version/0, index_value/0]).
 
@@ -1674,7 +1675,7 @@ get_last_modified(MD) ->
 %% Fetch the preferred vclock encoding method:
 -spec vclock_encoding_method() -> atom().
 vclock_encoding_method() ->
-    riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib).
+    ?CAP_VCLOCK_ENCODING.
 
 %% Encode a vclock in accordance with our capability setting:
 encode_vclock(VClock) ->


### PR DESCRIPTION
Capabilities are used to determine if a feature is safe to use, where this is determined by all nodes in the cluster being able to use that capability.

Capability calls are spread around the code.  Some capabilities continue to be check, even though there is no support for a version sufficiently old to not support the capability.

There is a minimal cost to capability checks, but that cost is non-zero.  There are also potential failure scenarios where there may be a fallback to the "wrong" capability.

Unify capability definitions, and where they are frequently requested and backwards-compatibility is no longer possible, hardcode them.