### PR TITLE
WIP: Refactor HTTP API

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -44,8 +44,8 @@
     {sext, {git, "https://github.com/OpenRiak/sext.git", {branch, "openriak-3.2"}}},
     {riak_pipe, {git, "https://github.com/OpenRiak/riak_pipe.git", {branch, "openriak-3.4"}}},
     {riak_dt, {git, "https://github.com/OpenRiak/riak_dt.git", {branch, "openriak-3.2"}}},
-    {riak_api, {git, "https://github.com/OpenRiak/riak_api.git", {branch, "openriak-3.4"}}},
+    {riak_api, {git, "https://github.com/OpenRiak/riak_api.git", {branch, "nhse-o34-orkv.i30-string"}}},
     {hyper, {git, "https://github.com/OpenRiak/hyper", {branch, "openriak-3.2"}}},
     {kv_index_tictactree, {git, "https://github.com/OpenRiak/kv_index_tictactree.git", {branch, "openriak-3.4"}}},
-    {rhc, {git, "https://github.com/OpenRiak/riak-erlang-http-client", {branch, "openriak-3.4"}}}
+    {rhc, {git, "https://github.com/OpenRiak/riak-erlang-http-client", {branch, "nhse-o34-nhskv.i30-string"}}}
 ]}.

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -752,7 +752,13 @@ charsets_provided(RD, Ctx0) ->
 %%      used in the PUT request that stored the document in Riak, or
 %%      "identity" and "gzip" if no encoding was specified at PUT-time.
 encodings_provided(RD, Ctx0) ->
-    DocCtx = ensure_doc(RD, Ctx0),
+    DocCtx =
+        case Ctx0#ctx.method of
+            UpdM when UpdM =:= 'PUT'; UpdM =:= 'POST'; UpdM =:= 'DELETE' ->
+                Ctx0;
+            _ ->
+                ensure_doc(RD, Ctx0)
+        end,
     case DocCtx#ctx.doc of
         {ok, _} ->
             case select_doc(DocCtx) of

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -176,21 +176,18 @@
               riak,         %% local | {node(), atom()} - params for riak client
               doc,          %% {ok, riak_object()}|{error, term()} - the object found
               vtag,         %% string() - vtag the user asked for
-              bucketprops,  %% proplist() - properties of the bucket
               links,        %% [link()] - links of the object
               index_fields, %% [index_field()]
               method,       %% atom() - HTTP method for the request
               ctype,        %% string() - extracted content-type provided
               charset,      %% string() | undefined - extracted character set provided
               timeout,      %% integer() - passed-in timeout value in ms
-              security      %% security context
+              security,     %% security context
+              header_map    %% map of http headers interesting within this module
              }).
 
--ifdef(namespaced_types).
+
 -type riak_kv_wm_object_dict() :: dict:dict().
--else.
--type riak_kv_wm_object_dict() :: dict().
--endif.
 
 -include_lib("webmachine/include/webmachine.hrl").
 -include("riak_kv_wm_raw.hrl").
@@ -204,12 +201,77 @@
 
 -type link() :: {{Bucket::binary(), Key::binary()}, Tag::binary()}.
 
--define(DEFAULT_TIMEOUT, 60000).
 -define(V1_BUCKET_REGEX, "/([^/]+)>; ?rel=\"([^\"]+)\"").
 -define(V1_KEY_REGEX, "/([^/]+)/([^/]+)>; ?riaktag=\"([^\"]+)\"").
 -define(V2_BUCKET_REGEX, "</buckets/([^/]+)>; ?rel=\"([^\"]+)\"").
 -define(V2_KEY_REGEX,
             "</buckets/([^/]+)/keys/([^/]+)>; ?riaktag=\"([^\"]+)\"").
+
+-define(BINHEAD_CTYPE, <<"content-type">>).
+-define(BINHEAD_IF_NOT_MODIFIED, <<"x-riak-if-not-modified">>).
+-define(BINHEAD_NONE_MATCH, <<"if-none-match">>).
+-define(BINHEAD_MATCH, <<"if-match">>).
+-define(BINHEAD_UNMODIFIED_SINCE, <<"if-unmodified-since">>).
+-define(BINHEAD_ENCODING, <<"content-encoding">>).
+-define(BINHEAD_ACCEPT, <<"accept">>).
+-define(BINHEAD_LINK, <<"link">>).
+-define(BINHEAD_VCLOCK, <<"x-riak-vclock">>).
+-define(PREFIX_USERMETA, "x-riak-meta-").
+-define(PREFIX_INDEX, "x-riak-index-").
+
+-spec make_reqheader_map(request_data()) -> #{binary() => any()}.
+make_reqheader_map(RD) ->
+    lists:foldl(
+        fun({HeadKey, HeadVal}, AccMap) ->
+            accumulate_header_info(
+                list_to_binary(HeadKey),
+                HeadVal,
+                AccMap
+            )
+        end,
+        maps:new(),
+        mochiweb_headers:to_normalised_list(wrq:req_headers(RD))
+    ).
+
+accumulate_header_info(<<?PREFIX_INDEX, Field/binary>>, T, MapAcc) ->
+    maps:update_with(
+        ?PREFIX_INDEX,
+        fun(Indices) -> [{Field, T}|Indices] end,
+        [{Field, T}],
+        MapAcc
+    );
+accumulate_header_info(<<?PREFIX_USERMETA, Meta/binary>>, V, MapAcc) ->
+    maps:update_with(
+        ?PREFIX_USERMETA,
+        fun(Indices) ->
+            [{<<?PREFIX_USERMETA, Meta/binary>>, V}|Indices]
+        end,
+        [{<<?PREFIX_USERMETA, Meta/binary>>, V}],
+        MapAcc
+    );
+accumulate_header_info(?BINHEAD_ACCEPT, V, MapAcc) ->
+    maps:put(?BINHEAD_ACCEPT, V, MapAcc);
+accumulate_header_info(?BINHEAD_CTYPE, V, MapAcc) ->
+    maps:put(?BINHEAD_CTYPE, V, MapAcc);
+accumulate_header_info(?BINHEAD_ENCODING, V, MapAcc) ->
+    maps:put(?BINHEAD_ENCODING, V, MapAcc);
+accumulate_header_info(?BINHEAD_VCLOCK, VC, MapAcc) ->
+    maps:put(
+        ?BINHEAD_VCLOCK,
+        riak_object:decode_vclock(base64:decode(VC)),
+        MapAcc);
+accumulate_header_info(?BINHEAD_LINK, V, MapAcc) ->
+    maps:put(?BINHEAD_LINK, V, MapAcc);
+accumulate_header_info(?BINHEAD_IF_NOT_MODIFIED, V, MapAcc) ->
+    maps:put(?BINHEAD_IF_NOT_MODIFIED, V, MapAcc);
+accumulate_header_info(?BINHEAD_UNMODIFIED_SINCE, V, MapAcc) ->
+    maps:put(?BINHEAD_UNMODIFIED_SINCE, V, MapAcc);
+accumulate_header_info(?BINHEAD_MATCH, V, MapAcc) ->
+    maps:put(?BINHEAD_MATCH, V, MapAcc);
+accumulate_header_info(?BINHEAD_NONE_MATCH, V, MapAcc) ->
+    maps:put(?BINHEAD_NONE_MATCH, V, MapAcc);
+accumulate_header_info(_DiscardIdx, _Value, MapAcc) ->
+    MapAcc.
 
 -spec init(proplists:proplist()) -> {ok, context()}.
 %% @doc Initialize this resource.  This function extracts the
@@ -220,8 +282,8 @@ init(Props) ->
               riak=proplists:get_value(riak, Props),
               bucket_type=proplists:get_value(bucket_type, Props)}}.
 
--spec service_available(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec service_available(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc Determine whether or not a connection to Riak
 %%      can be established.  This function also takes this
 %%      opportunity to extract the 'bucket' and 'key' path
@@ -248,6 +310,7 @@ service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
                         list_to_binary(
                             riak_kv_wm_utils:maybe_decode_uri(RD, K))
                 end,
+            HeaderMap = make_reqheader_map(RD),
             {true,
                 RD,
                 Ctx#ctx{
@@ -255,6 +318,7 @@ service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
                     client=C,
                     bucket=Bucket,
                     key=Key,
+                    header_map = HeaderMap,
                     vtag=wrq:get_qs_value(?Q_VTAG, RD)}};
         Error ->
             {false,
@@ -279,7 +343,7 @@ is_authorized(ReqData, Ctx) ->
                     "instead.">>, ReqData), Ctx}
     end.
 
--spec forbidden(#wm_reqdata{}, context()) -> term().
+-spec forbidden(request_data(), context()) -> term().
 forbidden(RD, Ctx) ->
     case riak_kv_wm_utils:is_forbidden(RD) of
         true ->
@@ -288,7 +352,7 @@ forbidden(RD, Ctx) ->
             validate(RD, Ctx)
     end.
 
--spec validate(#wm_reqdata{}, context()) -> term().
+-spec validate(request_data(), context()) -> term().
 validate(RD, Ctx=#ctx{security=undefined}) ->
     validate_resource(
         RD, Ctx, riak_kv_wm_utils:method_to_perm(Ctx#ctx.method));
@@ -301,7 +365,7 @@ validate(RD, Ctx=#ctx{security=Security}) ->
     maybe_validate_resource(Res, RD, Ctx, Perm).
 
 -spec maybe_validate_resource(
-        term(), #wm_reqdata{}, context(), string()) -> term().
+        term(), request_data(), context(), string()) -> term().
 maybe_validate_resource({false, Error, _}, RD, Ctx, _Perm) ->
     RD1 = wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD),
     {true, wrq:append_to_resp_body(
@@ -310,7 +374,7 @@ maybe_validate_resource({false, Error, _}, RD, Ctx, _Perm) ->
 maybe_validate_resource({true, _}, RD, Ctx, Perm) ->
     validate_resource(RD, Ctx, Perm).
 
--spec validate_resource(#wm_reqdata{}, context(), string()) -> term().
+-spec validate_resource(request_data(), context(), string()) -> term().
 validate_resource(RD, Ctx, Perm) when Perm == "riak_kv.get" ->
     %% Ensure the key is here, otherwise 404
     %% we do this early as it used to be done in the
@@ -341,21 +405,21 @@ validate_bucket_type(RD, Ctx) ->
             handle_common_error(bucket_type_unknown, RD, Ctx)
     end.
 
--spec allowed_methods(#wm_reqdata{}, context()) ->
-    {[atom()], #wm_reqdata{}, context()}.
+-spec allowed_methods(request_data(), context()) ->
+    {[atom()], request_data(), context()}.
 %% @doc Get the list of methods this resource supports.
 allowed_methods(RD, Ctx) ->
     {['HEAD', 'GET', 'POST', 'PUT', 'DELETE'], RD, Ctx}.
 
--spec allow_missing_post(#wm_reqdata{}, context()) ->
-    {true, #wm_reqdata{}, context()}.
+-spec allow_missing_post(request_data(), context()) ->
+    {true, request_data(), context()}.
 %% @doc Makes POST and PUT equivalent for creating new
 %%      bucket entries.
 allow_missing_post(RD, Ctx) ->
     {true, RD, Ctx}.
 
--spec malformed_request(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec malformed_request(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc Determine whether query parameters, request headers,
 %%      and request body are badly-formed.
 %%      Body format is checked to be valid JSON, including
@@ -401,7 +465,7 @@ malformed_request([H|T], RD, Ctx) ->
 %% PUT/POST.
 %% This should probably result in a 415 using the known_content_type callback
 malformed_content_type(RD, Ctx) ->
-    case wrq:get_req_header(?HEAD_CTYPE, RD) of
+    case maps:get(?BINHEAD_CTYPE, Ctx#ctx.header_map, undefined) of
         undefined ->
             {true, missing_content_type(RD), Ctx};
         RawCType ->
@@ -411,8 +475,8 @@ malformed_content_type(RD, Ctx) ->
             {false, RD, Ctx#ctx{ctype = ContentType, charset = Charset}}
     end.
 
--spec malformed_timeout_param(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec malformed_timeout_param(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc Check that the timeout parameter is are a
 %%      string-encoded integer.  Store the integer value
 %%      in context() if so.
@@ -436,8 +500,8 @@ malformed_timeout_param(RD, Ctx) ->
             end
     end.
 
--spec malformed_rw_params(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec malformed_rw_params(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc Check that r, w, dw, and rw query parameters are
 %%      string-encoded integers.  Store the integer values
 %%      in context() if so.
@@ -445,96 +509,103 @@ malformed_rw_params(RD, Ctx) ->
     Res =
     lists:foldl(fun malformed_rw_param/2,
                 {false, RD, Ctx},
-                [{#ctx.r, "r", "default"},
-                 {#ctx.w, "w", "default"},
-                 {#ctx.dw, "dw", "default"},
-                 {#ctx.rw, "rw", "default"},
-                 {#ctx.pw, "pw", "default"},
-                 {#ctx.node_confirms, "node_confirms", "default"},
-                 {#ctx.pr, "pr", "default"}]),
+                [{#ctx.r, "r", default},
+                 {#ctx.w, "w", default},
+                 {#ctx.dw, "dw", default},
+                 {#ctx.rw, "rw", default},
+                 {#ctx.pw, "pw", default},
+                 {#ctx.node_confirms, "node_confirms", default},
+                 {#ctx.pr, "pr", default}]),
     Res2 =
     lists:foldl(fun malformed_custom_param/2,
                  Res,
                  [{#ctx.sync_on_write,
                      "sync_on_write",
-                     "default",
+                     default,
                      [default, backend, one, all]}]),
     lists:foldl(fun malformed_boolean_param/2,
                 Res2,
-                [{#ctx.basic_quorum, "basic_quorum", "default"},
-                 {#ctx.notfound_ok, "notfound_ok", "default"},
-                 {#ctx.asis, "asis", "false"}]).
+                [{#ctx.basic_quorum, "basic_quorum", default},
+                 {#ctx.notfound_ok, "notfound_ok", default},
+                 {#ctx.asis, "asis", false}]).
 
--spec malformed_rw_param({Idx::integer(), Name::string(), Default::string()},
-                         {boolean(), #wm_reqdata{}, context()}) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec malformed_rw_param({Idx::integer(), Name::string(), Default::atom()},
+                         {boolean(), request_data(), context()}) ->
+    {boolean(), request_data(), context()}.
 %% @doc Check that a specific r, w, dw, or rw query param is a
 %%      string-encoded integer.  Store its result in context() if it
 %%      is, or print an error message in #wm_reqdata{} if it is not.
 malformed_rw_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
-    case catch normalize_rw_param(wrq:get_qs_value(Name, Default, RD)) of
-        P when (is_atom(P) orelse is_integer(P)) ->
-            {Result, RD, setelement(Idx, Ctx, P)};
-        _ ->
-            {true,
-             wrq:append_to_resp_body(
-               io_lib:format("~s query parameter must be an integer or "
-                   "one of the following words: 'one', 'quorum' or 'all'~n",
-                             [Name]),
-               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
-             Ctx}
+    case wrq:get_qs_value(Name, RD) of
+        undefined ->
+            {Result, RD, setelement(Idx, Ctx, Default)};
+        ExtractedString ->
+            case catch normalize_rw_param(ExtractedString) of
+                P when (is_atom(P) orelse is_integer(P)) ->
+                    {Result, RD, setelement(Idx, Ctx, P)};
+                _ ->
+                    {true,
+                    wrq:append_to_resp_body(
+                    io_lib:format("~s query parameter must be an integer or "
+                        "one of the following words: 'one', 'quorum' or 'all'~n",
+                                    [Name]),
+                    wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+                    Ctx}
+            end
     end.
 
 -spec malformed_custom_param({Idx::integer(),
                                     Name::string(),
-                                    Default::string(),
+                                    Default::atom(),
                                     AllowedValues::[atom()]},
-                                {boolean(), #wm_reqdata{}, context()}) ->
-   {boolean(), #wm_reqdata{}, context()}.
+                                {boolean(), request_data(), context()}) ->
+   {boolean(), request_data(), context()}.
 %% @doc Check that a custom parameter is one of the AllowedValues
 %% Store its result in context() if it is, or print an error message
 %% in #wm_reqdata{} if it is not.
 malformed_custom_param({Idx, Name, Default, AllowedValues}, {Result, RD, Ctx}) ->
-    AllowedValueTuples = [{V} || V <- AllowedValues],
-    Option=
-        lists:keyfind(
-            list_to_atom(
-                string:to_lower(
-                    wrq:get_qs_value(Name, Default, RD))),
-                1,
-                AllowedValueTuples),
-    case Option of
-        false ->
-            ErrorText =
-                "~s query parameter must be one of the following words: ~p~n",
-            {true,
-             wrq:append_to_resp_body(
-               io_lib:format(ErrorText, [Name, AllowedValues]),
-               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
-             Ctx};
-        _ ->
-            {Value} = Option,
-            {Result, RD, setelement(Idx, Ctx, Value)}
+    case wrq:get_qs_value(Name, RD) of
+        undefined ->
+            {Result, RD, setelement(Idx, Ctx, Default)};
+        ExtractedString ->
+            UsableValue = list_to_atom(string:lowercase(ExtractedString)),
+            case lists:member(UsableValue, AllowedValues) of
+                true ->
+                    {Result, RD, setelement(Idx, Ctx, UsableValue)};
+                false ->
+                    ErrorText =
+                        "~s query parameter must be one of the following words: ~p~n",
+                    {true,
+                    wrq:append_to_resp_body(
+                    io_lib:format(ErrorText, [Name, AllowedValues]),
+                    wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+                    Ctx}
+            end
     end.
 
 %% @doc Check that a specific query param is a
 %%      string-encoded boolean.  Store its result in context() if it
 %%      is, or print an error message in #wm_reqdata{} if it is not.
 malformed_boolean_param({Idx, Name, Default}, {Result, RD, Ctx}) ->
-    case string:to_lower(wrq:get_qs_value(Name, Default, RD)) of
-        "true" ->
-            {Result, RD, setelement(Idx, Ctx, true)};
-        "false" ->
-            {Result, RD, setelement(Idx, Ctx, false)};
-        "default" ->
-            {Result, RD, setelement(Idx, Ctx, default)};
-        _ ->
-            {true,
-            wrq:append_to_resp_body(
-              io_lib:format("~s query parameter must be true or false~n",
-                            [Name]),
-              wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
-             Ctx}
+    case wrq:get_qs_value(Name, RD) of
+        undefined ->
+            {Result, RD, setelement(Idx, Ctx, Default)};
+        ExtractedString ->
+            case string:lowercase(ExtractedString) of
+                "true" ->
+                    {Result, RD, setelement(Idx, Ctx, true)};
+                "false" ->
+                    {Result, RD, setelement(Idx, Ctx, false)};
+                "default" ->
+                    {Result, RD, setelement(Idx, Ctx, default)};
+                _ ->
+                    {true,
+                    wrq:append_to_resp_body(
+                    io_lib:format("~s query parameter must be true or false~n",
+                                    [Name]),
+                    wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+                    Ctx}
+            end
     end.
 
 normalize_rw_param("backend") -> backend;
@@ -544,15 +615,15 @@ normalize_rw_param("quorum") -> quorum;
 normalize_rw_param("all") -> all;
 normalize_rw_param(V) -> list_to_integer(V).
 
--spec malformed_link_headers(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec malformed_link_headers(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc Check that the Link header in the request() is valid.
 %%      Store the parsed links in context() if the header is valid,
 %%      or print an error in #wm_reqdata{} if it is not.
 %%      A link header should be of the form:
 %%        &lt;/Prefix/Bucket/Key&gt;; riaktag="Tag",...
 malformed_link_headers(RD, Ctx) ->
-    case catch get_link_heads(RD, Ctx) of
+    case catch get_link_heads(Ctx) of
         Links when is_list(Links) ->
             {false, RD, Ctx#ctx{links=Links}};
         _Error when Ctx#ctx.api_version == 1->
@@ -573,15 +644,15 @@ malformed_link_headers(RD, Ctx) ->
 
     end.
 
--spec malformed_index_headers(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec malformed_index_headers(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc Check that the Index headers (HTTP headers prefixed with index_")
 %%      are valid. Store the parsed headers in context() if valid,
 %%      or print an error in #wm_reqdata{} if not.
 %%      An index field should be of the form "index_fieldname_type"
 malformed_index_headers(RD, Ctx) ->
     %% Get a list of index_headers...
-    IndexFields1 = extract_index_fields(RD),
+    IndexFields1 = extract_index_fields(Ctx),
 
     %% Validate the fields. If validation passes, then the index
     %% headers are correctly formed.
@@ -596,37 +667,23 @@ malformed_index_headers(RD, Ctx) ->
              Ctx}
     end.
 
--spec extract_index_fields(#wm_reqdata{}) -> proplists:proplist().
+-spec extract_index_fields(context()) -> proplists:proplist().
 %% @doc Extract fields from headers prefixed by "x-riak-index-" in the
 %%      client's PUT request, to be indexed at write time.
-extract_index_fields(RD) ->
-    PrefixSize = length(?HEAD_INDEX_PREFIX),
-    {ok, RE} = re:compile(",\\s"),
-    F =
-        fun({K,V}, Acc) ->
-            KList = riak_kv_wm_utils:any_to_list(K),
-            case lists:prefix(?HEAD_INDEX_PREFIX, string:to_lower(KList)) of
-                true ->
-                    %% Isolate the name of the index field.
-                    IndexField =
-                        list_to_binary(
-                            element(2, lists:split(PrefixSize, KList))),
+extract_index_fields(Ctx) ->
+    RE = get_compiled_index_regex(),
+    lists:flatten(
+        lists:map(
+            fun({Field, Term}) ->
+                Values = re:split(Term, RE, [{return, binary}]),
+                [{Field, X} || X <- Values]
+            end,
+            maps:get(?PREFIX_INDEX, Ctx#ctx.header_map, [])
+        )
+    ).
 
-                    %% HACK ALERT: Split values on comma. The HTTP
-                    %% spec allows for comma separated tokens
-                    %% where the tokens can be quoted strings. We
-                    %% don't currently support quoted strings.
-                    %% (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
-                    Values = re:split(V, RE, [{return, binary}]),
-                    [{IndexField, X} || X <- Values] ++ Acc;
-                false ->
-                    Acc
-            end
-        end,
-    lists:foldl(F, [], mochiweb_headers:to_list(wrq:req_headers(RD))).
-
--spec content_types_provided(#wm_reqdata{}, context()) ->
-    {[{ContentType::string(), Producer::atom()}], #wm_reqdata{}, context()}.
+-spec content_types_provided(request_data(), context()) ->
+    {[{ContentType::string(), Producer::atom()}], request_data(), context()}.
 %% @doc List the content types available for representing this resource.
 %%      The content-type for a key-level request is the content-type that
 %%      was used in the PUT request that stored the document in Riak.
@@ -647,9 +704,9 @@ content_types_provided(RD, Ctx0) ->
               {"multipart/mixed", produce_multipart_body}], RD, DocCtx}
     end.
 
--spec charsets_provided(#wm_reqdata{}, context()) ->
+-spec charsets_provided(request_data(), context()) ->
     {no_charset|[{Charset::string(), Producer::function()}],
-     #wm_reqdata{}, context()}.
+     request_data(), context()}.
 %% @doc List the charsets available for representing this resource.
 %%      The charset for a key-level request is the charset that was used
 %%      in the PUT request that stored the document in Riak (none if
@@ -684,8 +741,8 @@ charsets_provided(RD, Ctx0) ->
             {no_charset, RD, DocCtx}
     end.
 
--spec encodings_provided(#wm_reqdata{}, context()) ->
-    {[{Encoding::string(), Producer::function()}], #wm_reqdata{}, context()}.
+-spec encodings_provided(request_data(), context()) ->
+    {[{Encoding::string(), Producer::function()}], request_data(), context()}.
 %% @doc List the encodings available for representing this resource.
 %%      The encoding for a key-level request is the encoding that was
 %%      used in the PUT request that stored the document in Riak, or
@@ -715,15 +772,15 @@ encodings_provided(RD, Ctx0) ->
             {riak_kv_wm_utils:default_encodings(), RD, DocCtx}
     end.
 
--spec content_types_accepted(#wm_reqdata{}, context()) ->
+-spec content_types_accepted(request_data(), context()) ->
     {[{ContentType::string(), Acceptor::atom()}],
-     #wm_reqdata{}, context()}.
+     request_data(), context()}.
 %% @doc Get the list of content types this resource will accept.
 %%      Whatever content type is specified by the Content-Type header
 %%      of a key-level PUT request will be accepted by this resource.
 %%      (A key-level put *must* include a Content-Type header.)
 content_types_accepted(RD, Ctx) ->
-    case wrq:get_req_header(?HEAD_CTYPE, RD) of
+    case maps:get(?BINHEAD_CTYPE, Ctx#ctx.header_map, undefined) of
         undefined ->
             %% user must specify content type of the data
             {[], RD, Ctx};
@@ -747,8 +804,8 @@ content_types_accepted(RD, Ctx) ->
             end
     end.
 
--spec resource_exists(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec resource_exists(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc Determine whether or not the requested item exists.
 %%      Documents exists if a read request to Riak returns {ok, riak_object()},
 %%      and either no vtag query parameter was specified, or the value of the
@@ -758,7 +815,7 @@ resource_exists(RD, Ctx0) ->
     ToFetch =
         case Method of
             UpdM when UpdM =:= 'PUT'; UpdM =:= 'POST'; UpdM =:= 'DELETE' ->
-                conditional_headers_present(RD) == true;
+                conditional_headers_present(Ctx0) == true;
             _ ->
                 true
         end,
@@ -800,7 +857,9 @@ resource_exists(RD, Ctx0) ->
 -spec is_conflict(request_data(), context()) ->
         {boolean(), request_data(), context()}.
 is_conflict(RD, Ctx) ->
-    case {Ctx#ctx.method, wrq:get_req_header(?HEAD_IF_NOT_MODIFIED, RD)} of
+    NotModified =
+        maps:get(?BINHEAD_IF_NOT_MODIFIED, Ctx#ctx.header_map, undefined),
+    case {Ctx#ctx.method, NotModified} of
         {_ , undefined} ->
             {false, RD, Ctx};
         {UpdM, NotModifiedClock} when UpdM =:= 'PUT'; UpdM =:= 'POST' ->
@@ -819,21 +878,17 @@ is_conflict(RD, Ctx) ->
             {false, RD, Ctx}
     end.
 
--spec conditional_headers_present(request_data()) -> boolean().
-conditional_headers_present(RD) ->
-    NoneMatch =
-        (wrq:get_req_header("If-None-Match", RD) =/= undefined),
-    Match =
-        (wrq:get_req_header("If-Match", RD) =/= undefined),
-    UnModifiedSince =
-        (wrq:get_req_header("If-Unmodified-Since", RD) =/= undefined),
-    NotModified =
-        (wrq:get_req_header(?HEAD_IF_NOT_MODIFIED, RD) =/= undefined),
+-spec conditional_headers_present(context()) -> boolean().
+conditional_headers_present(Ctx) ->
+    NoneMatch = maps:is_key(?BINHEAD_NONE_MATCH, Ctx#ctx.header_map),
+    Match = maps:is_key(?BINHEAD_MATCH, Ctx#ctx.header_map),
+    UnModifiedSince = maps:is_key(?BINHEAD_UNMODIFIED_SINCE, Ctx#ctx.header_map),
+    NotModified = maps:is_key(?BINHEAD_IF_NOT_MODIFIED, Ctx#ctx.header_map),
     (NoneMatch or Match or UnModifiedSince or NotModified).
 
 
--spec post_is_create(#wm_reqdata{}, context()) ->
-    {boolean(), #wm_reqdata{}, context()}.
+-spec post_is_create(request_data(), context()) ->
+    {boolean(), request_data(), context()}.
 %% @doc POST is considered a document-creation operation for bucket-level
 %%      requests (this makes webmachine call create_path/2, where the key
 %%      for the created document will be chosen).
@@ -844,8 +899,8 @@ post_is_create(RD, Ctx) ->
     %% key-POST is not create
     {false, RD, Ctx}.
 
--spec create_path(#wm_reqdata{}, context()) ->
-    {string(), #wm_reqdata{}, context()}.
+-spec create_path(request_data(), context()) ->
+    {string(), request_data(), context()}.
 %% @doc Choose the Key for the document created during a bucket-level POST.
 %%      This function also sets the Location header to generate a
 %%      201 Created response.
@@ -857,14 +912,14 @@ create_path(RD, Ctx=#ctx{prefix=P, bucket_type=T, bucket=B, api_version=V}) ->
                          RD),
      Ctx#ctx{key=list_to_binary(K)}}.
 
--spec process_post(#wm_reqdata{}, context()) ->
-    {true, #wm_reqdata{}, context()}.
+-spec process_post(request_data(), context()) ->
+    {true, request_data(), context()}.
 %% @doc Pass-through for key-level requests to allow POST to function
 %%      as PUT for clients that do not support PUT.
 process_post(RD, Ctx) -> accept_doc_body(RD, Ctx).
 
--spec accept_doc_body(#wm_reqdata{}, context()) ->
-    {true, #wm_reqdata{}, context()}.
+-spec accept_doc_body(request_data(), context()) ->
+    {true, request_data(), context()}.
 %% @doc Store the data the client is PUTing in the document.
 %%      This function translates the headers and body of the HTTP request
 %%      into their final riak_object() form, and executes the Riak put.
@@ -875,8 +930,12 @@ accept_doc_body(
             links=L, ctype=CType, charset=Charset,
             index_fields=IF}) ->
     Doc0 = riak_object:new(riak_kv_wm_utils:maybe_bucket_type(T,B), K, <<>>),
-    VclockDoc = riak_object:set_vclock(Doc0, decode_vclock_header(RD)),
-    UserMeta = extract_user_meta(RD),
+    VclockDoc =
+        riak_object:set_vclock(
+            Doc0,
+            maps:get(?BINHEAD_VCLOCK, Ctx#ctx.header_map, vclock:fresh())
+        ),
+    UserMeta = maps:get(?PREFIX_USERMETA, Ctx#ctx.header_map, []),
     CTypeMD = dict:store(?MD_CTYPE, CType, dict:new()),
     CharsetMD =
         if Charset /= undefined ->
@@ -885,7 +944,7 @@ accept_doc_body(
                 CTypeMD
         end,
     EncMD =
-        case wrq:get_req_header(?HEAD_ENCODING, RD) of
+        case maps:get(?BINHEAD_ENCODING, Ctx#ctx.header_map, undefined) of
             undefined -> CharsetMD;
             E -> dict:store(?MD_ENCODING, E, CharsetMD)
         end,
@@ -902,7 +961,7 @@ accept_doc_body(
             _ -> []
         end,
     Options = make_options(Options0, Ctx),
-    NoneMatch = (wrq:get_req_header("If-None-Match", RD) =/= undefined),
+    NoneMatch = maps:is_key(?BINHEAD_NONE_MATCH, Ctx#ctx.header_map),
     Options2 = case riak_kv_util:consistent_object(B) and NoneMatch of
                    true ->
                        [{if_none_match, true}|Options];
@@ -929,7 +988,7 @@ send_returnbody(RD, DocCtx, _HasSiblings = false) ->
 %% Handle the sibling case. Send either the sibling message body, or a
 %% multipart body, depending on what the client accepts.
 send_returnbody(RD, DocCtx, _HasSiblings = true) ->
-    AcceptHdr = wrq:get_req_header("Accept", RD),
+    AcceptHdr = maps:get(?BINHEAD_ACCEPT, DocCtx#ctx.header_map, undefined),
     PossibleTypes = ["multipart/mixed", "text/plain"],
     case webmachine_util:choose_media_type(PossibleTypes, AcceptHdr) of
         "multipart/mixed"  ->
@@ -958,19 +1017,8 @@ add_conditional_headers(RD, Ctx) ->
                 calendar:universal_time_to_local_time(LM)), RD4),
     {RD5,Ctx3}.
 
--spec extract_user_meta(#wm_reqdata{}) -> proplists:proplist().
-%% @doc Extract headers prefixed by X-Riak-Meta- in the client's PUT request
-%%      to be returned by subsequent GET requests.
-extract_user_meta(RD) ->
-    lists:filter(fun({K,_V}) ->
-                    lists:prefix(
-                        ?HEAD_USERMETA_PREFIX,
-                        string:to_lower(riak_kv_wm_utils:any_to_list(K)))
-                end,
-                mochiweb_headers:to_list(wrq:req_headers(RD))).
-
--spec multiple_choices(#wm_reqdata{}, context()) ->
-          {boolean(), #wm_reqdata{}, context()}.
+-spec multiple_choices(request_data(), context()) ->
+          {boolean(), request_data(), context()}.
 %% @doc Determine whether a document has siblings.  If the user has
 %%      specified a specific vtag, the document is considered not to
 %%      have sibling versions.  This is a safe assumption, because
@@ -1009,8 +1057,8 @@ multiple_choices(RD, Ctx) ->
                 multiple_choices})
     end.
 
--spec produce_doc_body(#wm_reqdata{}, context()) ->
-    {binary(), #wm_reqdata{}, context()}.
+-spec produce_doc_body(request_data(), context()) ->
+    {binary(), request_data(), context()}.
 %% @doc Extract the value of the document, and place it in the
 %%      response body of the request.  This function also adds the
 %%      Link, X-Riak-Meta- headers, and X-Riak-Index- headers to the
@@ -1069,8 +1117,8 @@ produce_doc_body(RD, Ctx) ->
                 multiple_choices})
     end.
 
--spec produce_sibling_message_body(#wm_reqdata{}, context()) ->
-    {iolist(), #wm_reqdata{}, context()}.
+-spec produce_sibling_message_body(request_data(), context()) ->
+    {iolist(), request_data(), context()}.
 %% @doc Produce the text message informing the user that there are multiple
 %%      values for this document, and giving that user the vtags of those
 %%      values so they can get to them with the vtag query param.
@@ -1082,8 +1130,8 @@ produce_sibling_message_body(RD, Ctx=#ctx{doc={ok, Doc}}) ->
                          encode_vclock_header(RD, Ctx)),
      Ctx}.
 
--spec produce_multipart_body(#wm_reqdata{}, context()) ->
-    {iolist(), #wm_reqdata{}, context()}.
+-spec produce_multipart_body(request_data(), context()) ->
+    {iolist(), request_data(), context()}.
 %% @doc Produce a multipart body representation of an object with multiple
 %%      values (siblings), each sibling being one part of the larger
 %%      document.
@@ -1126,7 +1174,7 @@ select_doc(#ctx{doc={ok, Doc}, vtag=Vtag}) ->
             {riak_object:get_update_metadata(Doc), UpdateValue}
     end.
 
--spec encode_vclock_header(#wm_reqdata{}, context()) -> #wm_reqdata{}.
+-spec encode_vclock_header(request_data(), context()) -> request_data().
 %% @doc Add the X-Riak-Vclock header to the response.
 encode_vclock_header(RD, #ctx{doc={ok, Doc}}) ->
     {Head, Val} = riak_object:vclock_header(Doc),
@@ -1135,16 +1183,6 @@ encode_vclock_header(RD, #ctx{doc={error, {deleted, VClock}}}) ->
     BinVClock = riak_object:encode_vclock(VClock),
     wrq:set_resp_header(
         ?HEAD_VCLOCK, binary_to_list(base64:encode(BinVClock)), RD).
-
--spec decode_vclock_header(#wm_reqdata{}) -> vclock:vclock().
-%% @doc Translate the X-Riak-Vclock header value from the request into
-%%      its Erlang representation.  If no vclock header exists, a fresh
-%%      vclock is returned.
-decode_vclock_header(RD) ->
-    case wrq:get_req_header(?HEAD_VCLOCK, RD) of
-        undefined -> vclock:fresh();
-             Head -> riak_object:decode_vclock(base64:decode(Head))
-    end.
 
 -spec ensure_doc(context()) -> context().
 %% @doc Ensure that the 'doc' field of the context() has been filled
@@ -1170,18 +1208,17 @@ ensure_doc(Ctx=#ctx{doc=undefined, bucket_type=T, bucket=B, key=K, client=C,
     end;
 ensure_doc(Ctx) -> Ctx.
 
--spec delete_resource(#wm_reqdata{}, context()) ->
-    {true, #wm_reqdata{}, context()}.
+-spec delete_resource(request_data(), context()) ->
+    {true, request_data(), context()}.
 %% @doc Delete the document specified.
 delete_resource(RD, Ctx=#ctx{bucket_type=T, bucket=B, key=K, client=C}) ->
     Options = make_options([], Ctx),
     BT = riak_kv_wm_utils:maybe_bucket_type(T,B),
     Result =
-        case wrq:get_req_header(?HEAD_VCLOCK, RD) of
+        case maps:get(?BINHEAD_VCLOCK, Ctx#ctx.header_map, undefined) of
             undefined ->
                 riak_client:delete(BT, K, Options, C);
-            _ ->
-                VC = decode_vclock_header(RD),
+            VC ->
                 riak_client:delete_vclock(BT, K, VC, Options, C)
         end,
     case Result of
@@ -1199,8 +1236,8 @@ md5(Bin) ->
     crypto:md5(Bin).
 -endif.
 
--spec generate_etag(#wm_reqdata{}, context()) ->
-    {undefined|string(), #wm_reqdata{}, context()}.
+-spec generate_etag(request_data(), context()) ->
+    {undefined|string(), request_data(), context()}.
 %% @doc Get the etag for this resource.
 %%      Documents will have an etag equal to their vtag. For documents with
 %%      siblings when no vtag is specified, this will be an etag derived from
@@ -1216,8 +1253,8 @@ generate_etag(RD, Ctx) ->
             {riak_core_util:integer_to_list(ETag, 62), RD, Ctx}
     end.
 
--spec last_modified(#wm_reqdata{}, context()) ->
-    {undefined|calendar:datetime(), #wm_reqdata{}, context()}.
+-spec last_modified(request_data(), context()) ->
+    {undefined|calendar:datetime(), request_data(), context()}.
 %% @doc Get the last-modified time for this resource.
 %%      Documents will have the last-modified time specified by the
 %%      riak_object.
@@ -1245,18 +1282,18 @@ normalize_last_modified(MD) ->
             httpd_util:convert_request_date(Rfc1123)
     end.
 
--spec get_link_heads(#wm_reqdata{}, context()) -> [link()].
+-spec get_link_heads(context()) -> [link()].
 %% @doc Extract the list of links from the Link request header.
 %%      This function will die if an invalid link header format
 %%      is found.
-get_link_heads(RD, Ctx) ->
+get_link_heads(Ctx) ->
     APIVersion = Ctx#ctx.api_version,
     Prefix = Ctx#ctx.prefix,
     Bucket = Ctx#ctx.bucket,
 
     %% Get a list of link headers...
-    LinkHeaders1 =
-        case wrq:get_req_header(?HEAD_LINK, RD) of
+    LinkHeaders =
+        case maps:get(?BINHEAD_LINK, Ctx#ctx.header_map, undefined) of
             undefined -> [];
             Heads -> string:tokens(Heads, ",")
         end,
@@ -1264,21 +1301,14 @@ get_link_heads(RD, Ctx) ->
     %% Decode the link headers. Throw an exception if we can't
     %% properly parse any of the headers...
     {BucketLinks, KeyLinks} =
-        case APIVersion of
-            1 ->
-                {ok, BucketRegex} =
-                    re:compile("</" ++ Prefix ++ ?V1_BUCKET_REGEX),
-                {ok, KeyRegex} =
-                    re:compile("</" ++ Prefix ++ ?V1_KEY_REGEX),
-                extract_links(LinkHeaders1, BucketRegex, KeyRegex);
-            %% @todo Handle links in API Version 3?
-            Two when Two >= 2 ->
-                {ok, BucketRegex} =
-                    re:compile(?V2_BUCKET_REGEX),
-                {ok, KeyRegex} =
-                    re:compile(?V2_KEY_REGEX),
-                extract_links(LinkHeaders1, BucketRegex, KeyRegex)
-        end,
+    case LinkHeaders of
+        [] ->
+            {[], []};
+        LinkHeaders ->
+            {KeyRegex, BucketRegex} =
+                get_compiled_link_regex(APIVersion, Prefix),
+            extract_links(LinkHeaders, BucketRegex, KeyRegex)
+    end,
 
     %% Validate that the only bucket header is pointing to the parent
     %% bucket...
@@ -1287,7 +1317,7 @@ get_link_heads(RD, Ctx) ->
         true ->
             KeyLinks;
         false ->
-            throw({invalid_link_headers, LinkHeaders1})
+            throw({invalid_link_headers, LinkHeaders})
     end.
 
 %% Run each LinkHeader string() through the BucketRegex and
@@ -1316,6 +1346,50 @@ extract_links_1([LinkHeader|Rest], BucketRegex, KeyRegex, BucketAcc, KeyAcc) ->
     end;
 extract_links_1([], _BucketRegex, _KeyRegex, BucketAcc, KeyAcc) ->
     {BucketAcc, KeyAcc}.
+
+-type mp() :: {re_pattern, _, _, _, _}.
+
+-spec get_compiled_link_regex(non_neg_integer(), string()) -> {mp(), mp()}.
+get_compiled_link_regex(1, Prefix) ->
+    case persistent_term:get(compiled_link_regex_v1, undefined) of
+        undefined ->
+            {ok, KeyRegex} = re:compile("</" ++ Prefix ++ ?V1_KEY_REGEX),
+            {ok, BucketRegex} = re:compile("</" ++ Prefix ++ ?V1_BUCKET_REGEX),
+            persistent_term:put(
+                compiled_link_regex_v1,
+                {KeyRegex, BucketRegex}
+            ),
+            {KeyRegex, BucketRegex};
+        PreCompiledExpressions ->
+            PreCompiledExpressions
+    end;
+get_compiled_link_regex(Two, _Prefix) when Two >= 2 ->
+    case persistent_term:get(compiled_link_regex_v2, undefined) of
+        undefined ->
+            {ok, KeyRegex} = re:compile(?V2_KEY_REGEX),
+            {ok, BucketRegex} = re:compile(?V2_BUCKET_REGEX),
+            persistent_term:put(
+                compiled_link_regex_v2,
+                {KeyRegex, BucketRegex}
+            ),
+            {KeyRegex, BucketRegex};
+        PreCompiledExpressions ->
+            PreCompiledExpressions
+    end.
+
+-spec get_compiled_index_regex() -> mp().
+get_compiled_index_regex() ->
+    case persistent_term:get(compiled_index_regex, undefined) of
+        undefined ->
+            {ok, IndexRegex} = re:compile(",\\s"),
+            persistent_term:put(
+                compiled_index_regex,
+                IndexRegex
+            ),
+            IndexRegex;
+        PreCompiledIndexRegex ->
+            PreCompiledIndexRegex
+    end.
 
 -spec get_ctype(riak_kv_wm_object_dict(), term()) -> string().
 %% @doc Work out the content type for this object - use the metadata if provided


### PR DESCRIPTION
Refactor HTTP GET/PUT API to try and improve efficiency.

Using the general_api _perf test, profiling a node handling all HTTP requests, prior to the change the profile was like:

```
FUNCTION                                     CALLS        %    TIME  [uS / CALLS]
--------                                     -----  -------    ----  [----------]
webmachine_resource:do/3                      3396     0.60     825  [      0.24]
string:strip_right/2                         10898     0.62     845  [      0.08]
lists:keyfind/3                              14311     0.63     855  [      0.06]
webmachine_resource:resource_call/3           2384     0.64     875  [      0.37]
gb_trees:lookup_1/2                          16905     0.71     974  [      0.06]
string:tokens_single_2/4                     24313     0.75    1022  [      0.04]
zlib:deflate_nif/4                             103     0.77    1050  [     10.19]
erlang:put/2                                 18841     0.84    1154  [      0.06]
webmachine_dispatcher:try_host_binding1/6     5127     0.88    1201  [      0.23]
lists:reverse/2                              14809     0.88    1206  [      0.08]
gen_statem:loop_receive/3                       86     0.90    1233  [     14.34]
erlang:binary_to_term/1                        340     0.98    1338  [      3.94]
gb_trees:insert_1/4                          11281     0.99    1357  [      0.12]
gen_fsm:loop/8                                 674     1.06    1450  [      2.15]
gen:do_call/4                                  645     1.10    1498  [      2.32]
lists:reverse/1                              21250     1.11    1520  [      0.07]
exometer_probe:loop/1                          768     1.16    1584  [      2.06]
erts_internal:port_command/3                   267     1.17    1603  [      6.00]
erts_internal:port_control/3                  1689     1.18    1618  [      0.96]
mochiweb_http:headers/6                        909     1.82    2492  [      2.74]
ets:lookup/2                                  2582     2.53    3455  [      1.34]
string:to_lower_char/1                      111820     3.42    4671  [      0.04]
gen_server:loop/7                              824     6.65    9086  [     11.03]
mochiweb_http:request/3                        125     7.60   10390  [     83.12]
string:'-to_lower/1-lc$^0/1-0-'/1           121272     9.90   13534  [      0.11]
-----------------------------------------  -------  -------  ------  [----------]
Total:                                     1040513  100.00%  136652  [      0.13]

FUNCTION                                     CALLS        %    TIME  [uS / CALLS]
--------                                     -----  -------    ----  [----------]
lists:keyfind/3                              13819     0.62     811  [      0.06]
string:strip_right/2                         10657     0.63     831  [      0.08]
prim_file:read_nif/2                            87     0.70     921  [     10.59]
zlib:deflate_nif/4                              99     0.73     951  [      9.61]
gb_trees:lookup_1/2                          16853     0.73     956  [      0.06]
string:tokens_single_2/4                     23795     0.76     992  [      0.04]
erlang:put/2                                 18265     0.83    1082  [      0.06]
webmachine_dispatcher:try_host_binding1/6     5002     0.88    1149  [      0.23]
gen_statem:loop_receive/3                       93     0.93    1225  [     13.17]
gb_trees:insert_1/4                          11014     0.97    1269  [      0.12]
lists:reverse/2                              14378     0.97    1270  [      0.09]
exometer_probe:loop/1                          751     1.03    1352  [      1.80]
gen:do_call/4                                  628     1.05    1371  [      2.18]
erlang:binary_to_term/1                        364     1.08    1421  [      3.90]
lists:reverse/1                              20655     1.13    1479  [      0.07]
erts_internal:port_command/3                   244     1.21    1590  [      6.52]
erts_internal:port_control/3                  1683     1.28    1676  [      1.00]
gen_fsm:loop/8                                 605     1.37    1801  [      2.98]
mochiweb_http:headers/6                        919     2.19    2878  [      3.13]
ets:lookup/2                                  2430     2.50    3285  [      1.35]
string:to_lower_char/1                      110384     3.51    4599  [      0.04]
gen_server:loop/7                              776     6.81    8930  [     11.51]
mochiweb_http:request/3                        122     8.51   11156  [     91.44]
string:'-to_lower/1-lc$^0/1-0-'/1           119691    10.15   13315  [      0.11]
-----------------------------------------  -------  -------  ------  [----------]
Total:                                     1007341  100.00%  131147  [      0.13]

```

After this refactor:

```
FUNCTION                                    CALLS        %    TIME  [uS / CALLS]
--------                                    -----  -------    ----  [----------]
webmachine_resource:resource_call/3          2317     0.65     821  [      0.35]
lists:keyfind/3                             13846     0.68     866  [      0.06]
webmachine_resource:do/3                     3293     0.79    1005  [      0.31]
erlang:put/2                                18248     0.84    1068  [      0.06]
erlang:binary_to_term/1                       305     0.85    1072  [      3.51]
gb_trees:insert_1/4                         11332     0.85    1081  [      0.10]
zlib:deflate_nif/4                            103     0.89    1131  [     10.98]
exometer_probe:loop/1                         738     0.89    1131  [      1.53]
webmachine_dispatcher:try_host_binding1/6    5002     0.90    1140  [      0.23]
gen_statem:loop_receive/3                      78     0.93    1175  [     15.06]
gen:do_call/4                                 598     0.98    1241  [      2.08]
string:trim_t/3                             10632     1.00    1262  [      0.12]
lists:reverse/2                             15051     1.03    1298  [      0.09]
erts_internal:port_command/3                  244     1.20    1524  [      6.25]
lists:reverse/1                             22539     1.24    1564  [      0.07]
string:lexeme_pick/3                        17830     1.26    1598  [      0.09]
gen_fsm:loop/8                                621     1.27    1610  [      2.59]
erts_internal:port_control/3                 1660     1.29    1627  [      0.98]
lists:member/2                              32688     1.30    1644  [      0.05]
string:search_cp/1                          19848     1.43    1807  [      0.09]
mochiweb_http:headers/6                       898     2.07    2616  [      2.91]
ets:lookup/2                                 2434     2.67    3379  [      1.39]
string:lowercase_list/2                     76913     3.52    4462  [      0.06]
gen_server:loop/7                             755     6.77    8574  [     11.36]
mochiweb_http:request/3                       122     7.57    9587  [     78.58]
-----------------------------------------  ------  -------  ------  [----------]
Total:                                     937636  100.00%  126603  [      0.14]

FUNCTION                                    CALLS        %    TIME  [uS / CALLS]
--------                                    -----  -------    ----  [----------]
webmachine_resource:do/3                     3090     0.70     838  [      0.27]
erlang:put/2                                17130     0.81     977  [      0.06]
gb_trees:insert_1/4                         10819     0.85    1026  [      0.09]
webmachine_dispatcher:try_host_binding1/6    4633     0.88    1057  [      0.23]
exometer_probe:loop/1                         672     0.94    1135  [      1.69]
erlang:binary_to_term/1                       316     0.95    1145  [      3.62]
string:trim_t/3                             10040     0.98    1184  [      0.12]
gen:do_call/4                                 559     0.99    1187  [      2.12]
lists:reverse/2                             14119     1.01    1214  [      0.09]
gen_fsm:loop/8                                542     1.02    1224  [      2.26]
erts_internal:port_command/3                  229     1.08    1303  [      5.69]
erts_internal:port_control/3                 1553     1.20    1442  [      0.93]
lists:reverse/1                             21102     1.22    1469  [      0.07]
string:lexeme_pick/3                        16825     1.26    1521  [      0.09]
mochiweb_http:headers/6                       844     1.30    1563  [      1.85]
lists:member/2                              30839     1.30    1569  [      0.05]
string:search_cp/1                          18720     1.41    1699  [      0.09]
gen_statem:loop_receive/3                      76     1.51    1824  [     24.00]
prim_file:read_nif/2                           75     1.64    1980  [     26.40]
prim_file:pwrite_nif/3                          5     2.01    2427  [    485.40]
ets:lookup/2                                 2229     2.51    3027  [      1.36]
string:lowercase_list/2                     72807     3.40    4090  [      0.06]
gen_server:loop/7                             686     5.91    7118  [     10.38]
mochiweb_http:request/3                       114    11.25   13547  [    118.83]
-----------------------------------------  ------  -------  ------  [----------]
[info] Total:                                     873808  100.00%  120463  [      0.14]
```

In theory the refactoring as removed the biggest cause of CPU use in the HTTP API - lower-casing strings.  This is supported in the profile.

the refactoring reduces the number of repeated string lowerings, and across the board stops using deprecated string functions