### PR TITLE
Nhse o32 orkv.i29 leveledasync

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -36,7 +36,7 @@
 ]}.
 
 {deps, [
-    {riak_core, {git, "https://github.com/OpenRiak/riak_core.git", {branch, "openriak-3.2"}}},
+    {riak_core, {git, "https://github.com/OpenRiak/riak_core.git", {branch, "nhse-o32-orkv.i29-asyncfun"}}},
     {sidejob, {git, "https://github.com/OpenRiak/sidejob.git", {branch, "openriak-3.2"}}},
     {bitcask, {git, "https://github.com/OpenRiak/bitcask.git", {branch, "openriak-3.2"}}},
     {redbug, {git, "https://github.com/OpenRiak/redbug", {branch, "openriak-3.2"}}},

--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -24,12 +24,12 @@
 
 -export([callback_after/3]).
 
--type fold_buckets_fun() :: fun((binary(), any()) -> any() | no_return()).
--type fold_keys_fun() :: fun((binary(), binary(), any()) -> any() |
-                                                            no_return()).
--type fold_objects_fun() :: fun((binary(), binary(), term(), any()) ->
-                                       any() |
-                                       no_return()).
+-type fold_buckets_fun() ::
+    fun((binary(), any()) -> any() | no_return()).
+-type fold_keys_fun() :: 
+    fun((binary(), binary(), any()) -> any() | no_return()).
+-type fold_objects_fun() :: 
+    fun((binary(), binary(), term(), any()) -> any() | no_return()).
 
 -type index_spec() :: {add | remove, binary(), riak_object:index_value()}.
 
@@ -43,7 +43,13 @@
 -type state() :: term().
 -type fold_acc() :: term().
 -type fold_opts() :: [term()]. %% TODO maybe more specific? [{atom(), term()}]?
--type fold_result() :: {ok, fold_acc()} | {async, fun()} | {error, term()}.
+-type fold_result() :: 
+    {ok, fold_acc()} | {async, fun(() -> any())} | {error, term()}.
+
+-type data_size_fun() ::
+    fun(() -> {non_neg_integer(), bytes | objects} | undefined).
+
+-optional_callbacks([data_size/1]).
 
 -callback api_version() -> {ok, number()}.
 
@@ -77,6 +83,11 @@
 -callback status(state()) -> [{atom(), term()}].
 
 -callback callback(reference(), Msg :: term(), state()) -> {ok, state()}.
+
+-callback data_size(state()) -> 
+    {non_neg_integer(), bytes | objects} |
+    {data_size_fun(), dynamic | async} |
+    undefined.
 
 %% Queue a callback for the backend after Time ms.
 -spec callback_after(integer(), reference(), term()) -> reference().

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -278,10 +278,12 @@ delete(Bucket, Key, _IndexSpecs,
     {ok, State}.
 
 %% @doc Fold over all the buckets.
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [],
+    state()) ->
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, #state{opts=BitcaskOpts,
                                                data_dir=DataFile,
                                                ref=Ref,
@@ -321,10 +323,12 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{opts=BitcaskOpts,
     end.
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun()} | {error, term()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, term()} | {async, fun(() -> any())} | {error, term()}.
 fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
                                          data_dir=DataFile,
                                          ref=Ref,
@@ -359,10 +363,12 @@ fold_keys(FoldKeysFun, Acc, Opts, #state{opts=BitcaskOpts,
     end.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_objects(FoldObjectsFun, Acc, Opts, #state{opts=BitcaskOpts,
                                                data_dir=DataFile,
                                                ref=Ref,

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -365,10 +365,12 @@ delete(Bucket, PrimaryKey, IndexSpecs, #state{ref=Ref,
     end.
 
 %% @doc Fold over all the buckets
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [],
-                   state()) -> {ok, any()} | {async, fun()}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [],
+    state()) ->
+        {ok, any()} | {async, fun(() -> any())}.
 fold_buckets(FoldBucketsFun, Acc, Opts, #state{fold_opts=FoldOpts,
                                                ref=Ref}) ->
     FoldFun = fold_buckets_fun(FoldBucketsFun),
@@ -393,10 +395,12 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{fold_opts=FoldOpts,
     end.
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, term()} | {async, fun(() -> any())}.
 fold_keys(FoldKeysFun, Acc, Opts, #state{fold_opts=FoldOpts,
                                          fixed_indexes=FixedIdx,
                                          legacy_indexes=WriteLegacyIdx,
@@ -508,10 +512,12 @@ legacy_key_fold(_Ref, _FoldFun, Acc, _FoldOpts, _Query) ->
     Acc.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())}.
 fold_objects(FoldObjectsFun, Acc, Opts, #state{fold_opts=FoldOpts,
                                                ref=Ref}) ->
     %% Figure out how we should limit the fold: by bucket, by

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -616,9 +616,7 @@ status(_State) ->
 
 %% @doc Get an estimate of the data_size for this leveled backend
 -spec data_size(state()) ->
-    undefined |
-    {non_neg_integer(), objects} |
-    {fun(() -> {non_neg_integer(), objects}), dynamic}.
+    {fun(() -> {non_neg_integer(), objects}), async}.
 data_size(#state{bookie=Bookie}) ->
     TictacTreeSize = 1024 * 1024,
     SegmentCount = 64,
@@ -645,7 +643,7 @@ data_size(#state{bookie=Bookie}) ->
                 ),
             {DataSizeGuesser(), objects}
         end,
-    {F, dynamic}.
+    {F, async}.
 
 
 %% @doc Register an asynchronous callback

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -309,18 +309,22 @@ fold_buckets(FoldBucketsFun, Acc, Opts, #state{data_ref=DataRef}) ->
     end.
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, term()} | {async, fun()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, term()} | {async, fun(() -> any())}.
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
    fold(fun fold_keys_fun/2, FoldKeysFun, Acc, Opts, State).
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())}.
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     fold(fun fold_objects_fun/2, FoldObjectsFun, Acc, Opts, State).
 
@@ -330,7 +334,7 @@ fold_objects(FoldObjectsFun, Acc, Opts, State) ->
            riak_kv_backend:fold_keys_fun(), any(),
            [{atom(), term()}],
            state()) ->
-                   {ok, any()} | {async, function()}.
+                   {ok, any()} | {async, fun(() -> any())}.
 fold(FoldTypeFun, FoldFun0, Acc, Opts, #state{data_ref=DataRef, index_ref=IndexRef}) ->
     %% Figure out how we should limit the fold: by bucket, by
     %% secondary index, or neither (fold across everything.)
@@ -424,7 +428,9 @@ status(#state{data_ref=DataRef,
 
 %% @doc Get the size of the memory backend. Returns a dynamic size
 %%      since new writes may appear in an ets fold
--spec data_size(state()) -> undefined | {function(), dynamic}.
+-spec data_size(
+    state()) -> 
+        {fun(() -> {non_neg_integer(), objects} | undefined), dynamic}.
 data_size(#state{data_ref=DataRef}) ->
     F = fun() ->
                 DataStatus = ets:info(DataRef),

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -288,10 +288,12 @@ delete(Bucket, Key, IndexSpecs, State) ->
     end.
 
 %% @doc Fold over all the buckets
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) ->
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
     fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State,
              fun default_backend_filter/5).
@@ -302,10 +304,12 @@ fold_indexes(FoldIndexFun, Acc, Opts, State) ->
             fun indexes_filter/5).
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
@@ -316,10 +320,12 @@ fold_keys(FoldKeysFun, Acc, Opts, State) ->
     end.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->

--- a/src/riak_kv_multi_prefix_backend.erl
+++ b/src/riak_kv_multi_prefix_backend.erl
@@ -325,18 +325,22 @@ delete(Bucket, Key, IndexSpecs, State) ->
     end.
 
 %% @doc Fold over all the buckets
--spec fold_buckets(riak_kv_backend:fold_buckets_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_buckets(
+    riak_kv_backend:fold_buckets_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_buckets(FoldBucketsFun, Acc, Opts, State) ->
     fold_all(fold_buckets, FoldBucketsFun, Acc, Opts, State).
 
 %% @doc Fold over all the keys for one or all buckets.
--spec fold_keys(riak_kv_backend:fold_keys_fun(),
-                any(),
-                [{atom(), term()}],
-                state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_keys(
+    riak_kv_backend:fold_keys_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_keys(FoldKeysFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->
@@ -346,10 +350,12 @@ fold_keys(FoldKeysFun, Acc, Opts, State) ->
     end.
 
 %% @doc Fold over all the objects for one or all buckets.
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()} | {error, term()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())} | {error, term()}.
 fold_objects(FoldObjectsFun, Acc, Opts, State) ->
     case proplists:get_value(bucket, Opts) of
         undefined ->

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -329,10 +329,12 @@ fold_keys(FoldKeysFun, Accum, Opts, State) ->
     end.
 
 %% @doc Fold over all the objects for one or all buckets, yes, sir!
--spec fold_objects(riak_kv_backend:fold_objects_fun(),
-                   any(),
-                   [{atom(), term()}],
-                   state()) -> {ok, any()} | {async, fun()}.
+-spec fold_objects(
+    riak_kv_backend:fold_objects_fun(),
+    any(),
+    [{atom(), term()}],
+    state()) -> 
+        {ok, any()} | {async, fun(() -> any())}.
 fold_objects(FoldObjectsFun, Accum, Opts, State) ->
     KeyCount = State#state.key_count,
     ValueSize = State#state.default_size,


### PR DESCRIPTION
Allow use of {F, async} response to data_size/1 backend function.

The function dialyzer specs within the backend callback have been extended to at least recognise arity.