### PR TITLE
Don't restart backend on drop

### DIFF
--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -580,9 +580,9 @@ fold_heads(FoldHeadsFun, Acc, Opts, #state{bookie=Bookie}) ->
 
 %% @doc Delete all objects from this leveled backend
 -spec drop(state()) -> {ok, state()} | {error, term(), state()}.
-drop(#state{bookie=Bookie, partition=Partition, config=Config}=_State) ->
+drop(#state{bookie=Bookie}=State) ->
     ok = leveled_bookie:book_destroy(Bookie),
-    start(Partition, Config).
+    {ok, State}.
 
 %% @doc Returns true if this leveled backend contains any
 %% non-tombstone values; otherwise returns false.


### PR DESCRIPTION
Hard to understand why this was ever this way.  No other backend restarts after a drop.  Has existed since initial commit of riak_kv_leveled_backend.

Creates confusion for the operator looking at logs.