### PR TITLE
Do not reconcile a single object

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -244,7 +244,7 @@ reconcile(Objects, AllowMultiple) ->
 %% conflicting objects will remain.
 remove_dominated(Objects) ->
     All = sets:from_list(Objects, [{version, 2}]),
-    Del = sets:from_list(ancestors(Objects)),
+    Del = sets:from_list(ancestors(Objects), [{version, 2}]),
     sets:to_list(sets:subtract(All, Del)).
 
 %% @doc Take a list of {Idx, {ok, Object}} tuples that have been the

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -227,6 +227,8 @@ strict_descendant(O1, O2) ->
 %%       contain the value of the most-recently-updated object, as per the
 %%       X-Riak-Last-Modified header.
 -spec reconcile([riak_object()], boolean()) -> riak_object().
+reconcile([RObj], _AllowMultiple) ->
+    RObj;
 reconcile(Objects, AllowMultiple) ->
     RObj = reconcile(remove_dominated(Objects)),
     case AllowMultiple of
@@ -241,7 +243,7 @@ reconcile(Objects, AllowMultiple) ->
 %% dominated by any other object in the list. Only concurrent /
 %% conflicting objects will remain.
 remove_dominated(Objects) ->
-    All = sets:from_list(Objects),
+    All = sets:from_list(Objects, [{version, 2}]),
     Del = sets:from_list(ancestors(Objects)),
     sets:to_list(sets:subtract(All, Del)).
 

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -243,9 +243,9 @@ reconcile(Objects, AllowMultiple) ->
 %% dominated by any other object in the list. Only concurrent /
 %% conflicting objects will remain.
 remove_dominated(Objects) ->
-    All = sets:from_list(Objects, [{version, 2}]),
-    Del = sets:from_list(ancestors(Objects), [{version, 2}]),
-    sets:to_list(sets:subtract(All, Del)).
+    All = ordsets:from_list(Objects),
+    Del = ordsets:from_list(ancestors(Objects)),
+    ordsets:to_list(ordsets:subtract(All, Del)).
 
 %% @doc Take a list of {Idx, {ok, Object}} tuples that have been the
 %% result of HEAD requests or GET requests. This list MUST be in the


### PR DESCRIPTION
This avoids the `sets:from_list/1` conversion in the `remove_dominated/1` function, by not reconciling a singleton object.  When using version 1 of sets - this would otherwise use the deprecated  and expensive `erlang:phash/2` function, across the whole object.

For completeness, if multiple objects cannot be avoided - this changed to use v2 sets so that the old hash function is still not required.