### PR TITLE
Do not reconcile a single object (#53)

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -223,6 +223,8 @@ strict_descendant(O1, O2) ->
 %%       contain the value of the most-recently-updated object, as per the
 %%       X-Riak-Last-Modified header.
 -spec reconcile([riak_object()], boolean()) -> riak_object().
+reconcile([RObj], _AllowMultiple) ->
+    RObj;
 reconcile(Objects, AllowMultiple) ->
     RObj = reconcile(remove_dominated(Objects)),
     case AllowMultiple of
@@ -237,9 +239,9 @@ reconcile(Objects, AllowMultiple) ->
 %% dominated by any other object in the list. Only concurrent /
 %% conflicting objects will remain.
 remove_dominated(Objects) ->
-    All = sets:from_list(Objects),
-    Del = sets:from_list(ancestors(Objects)),
-    sets:to_list(sets:subtract(All, Del)).
+    All = ordsets:from_list(Objects),
+    Del = ordsets:from_list(ancestors(Objects)),
+    ordsets:to_list(ordsets:subtract(All, Del)).
 
 %% @doc Take a list of {Idx, {ok, Object}} tuples that have been the
 %% result of HEAD requests or GET requests. This list MUST be in the


### PR DESCRIPTION
* Do not reconcile a single object

This avoids the sets:from_list/1 conversion in the `remove_dominated/1` function.  Suing version/1 this relies on the deprecated  and expensive `erlang:phash/2` function.

For completeness, if multiple objects cannot be avoided - use v2 sets so that the old hash function is still not required.

* Use version 2 for both add All and Del

* Use ordsets not v2 sets