### PR TITLE
Nhse o34 orkv.i54 propfetch

### DIFF
--- a/eqc/ec_eqc.erl
+++ b/eqc/ec_eqc.erl
@@ -928,7 +928,7 @@ syntactic_put_merge(CurObj, UpdObj) ->
 coord_put_merge(undefined, UpdObj, NodeId, Timestamp) ->
     riak_object:increment_vclock(UpdObj, NodeId, Timestamp);
 coord_put_merge(LocalObj, PutObj, NodeId, Timestamp) ->
-    riak_object:update(false, LocalObj, PutObj, NodeId, Timestamp).
+    riak_object:update(false, LocalObj, PutObj, NodeId, Timestamp, false, true).
 
 get_counter(Id, VC) ->            
     case lists:keyfind(Id, 1, VC) of

--- a/eqc/fsm_eqc_vnode.erl
+++ b/eqc/fsm_eqc_vnode.erl
@@ -296,5 +296,8 @@ put_merge(CurObj, UpdObj, Options) ->
     %% doesn't support epochs in this test, it is safe to set
     %% IsNewEpoch to false
     IsNewEpoch = false,
-    {_, ResObj} = riak_kv_vnode:put_merge(Coord, false, CurObj, UpdObj, {IsNewEpoch, VnodeId}, Ts),
+    {_, ResObj} =
+        riak_kv_vnode:put_merge(
+            Coord, false, CurObj, UpdObj, {IsNewEpoch, VnodeId}, Ts, false, true
+        ),
     ResObj.

--- a/eqc/kv679_eqc.erl
+++ b/eqc/kv679_eqc.erl
@@ -410,7 +410,7 @@ coord_put(VId, Epoch, {ok, LocalObj}, IncomingObject) ->
                           Acted when is_integer(Acted) ->
                               maybe_new_epoch_actor(VId, Epoch, LocalObj, IncomingObject)
                       end,
-    Obj = riak_object:update(false, LocalObj, IncomingObject, Actor, StartTime),
+    Obj = riak_object:update(false, LocalObj, IncomingObject, Actor, StartTime, false, true),
     {ok, Dot} = vclock:get_dot(Actor, riak_object:vclock(Obj)),
     {Epoch2, Obj, Dot}.
 

--- a/eqc/put_fsm_eqc.erl
+++ b/eqc/put_fsm_eqc.erl
@@ -93,7 +93,7 @@ setup() ->
     meck:new(riak_core_bucket),
     meck:expect(riak_core_bucket, get_bucket,
                 fun(_Bucket) ->
-                        [dvv_enabled]
+                        [{dvv_enabled, true}]
                 end),
     %% Check networking/clients are set up
     ?assert(node() /= 'nonode@nohost'),
@@ -270,14 +270,19 @@ prop_basic_put() ->
 
                        %% Run the test and wait for all processes spawned by it to settle.
                        process_flag(trap_exit, true),
-                       {ok, PutPid} = riak_kv_put_fsm:test_link({raw, ?REQ_ID, self()},
-                                                                Object,
-                                                                Options,
-                                                                [{starttime, riak_core_util:moment()},
-                                                                 {n, N},
-                                                                 {bucket_props, BucketProps},
-                                                                 {preflist2, PL2},
-                                                                 {coord_pl_entry, CoordPLEntry}]),
+                       {ok, PutPid} =
+                        riak_kv_put_fsm:test_link(
+                            {raw, ?REQ_ID, self()},
+                            Object,
+                            Options,
+                            [
+                                {starttime, riak_core_util:moment()},
+                                {n, N},
+                                {bucket_props, BucketProps},
+                                {preflist2, PL2},
+                                {coord_pl_entry, CoordPLEntry}
+                            ]
+                        ),
                        ok = riak_kv_test_util:wait_for_pid(PutPid),
                        ok = riak_kv_test_util:wait_for_children(PutPid),
                        Res = fsm_eqc_util:wait_for_req_id(?REQ_ID, PutPid),

--- a/eqc/put_fsm_eqc.erl
+++ b/eqc/put_fsm_eqc.erl
@@ -278,7 +278,7 @@ prop_basic_put() ->
                             [
                                 {starttime, riak_core_util:moment()},
                                 {n, N},
-                                {bucket_props_list, BucketProps},
+                                {bucket_props, BucketProps},
                                 {preflist2, PL2},
                                 {coord_pl_entry, CoordPLEntry}
                             ]

--- a/eqc/put_fsm_eqc.erl
+++ b/eqc/put_fsm_eqc.erl
@@ -278,7 +278,7 @@ prop_basic_put() ->
                             [
                                 {starttime, riak_core_util:moment()},
                                 {n, N},
-                                {bucket_props, BucketProps},
+                                {bucket_props_list, BucketProps},
                                 {preflist2, PL2},
                                 {coord_pl_entry, CoordPLEntry}
                             ]

--- a/eqc/riak_object_dvv_statem.erl
+++ b/eqc/riak_object_dvv_statem.erl
@@ -288,7 +288,7 @@ coord_put(VNode, Value, Time, VNodeData) ->
 coord_put_ro(VNode, NewObj, undefined, Time) ->
     riak_object:increment_vclock(NewObj, VNode, Time);
 coord_put_ro(VNode, NewObj, OldObj, Time) ->
-    riak_object:update(false, OldObj, NewObj, VNode, Time).
+    riak_object:update(false, OldObj, NewObj, VNode, Time, false, true).
 
 %% Update the DVVSet as if in a co-ordinating vnode
 coord_put_dvv(VNode, DVV, undefined) ->

--- a/include/riak_kv_capability.hrl
+++ b/include/riak_kv_capability.hrl
@@ -52,7 +52,7 @@
 % -define(CAP_OBJECT_FORMAT,
 %     riak_core_capability:get({riak_kv, object_format}, v0)
 % ).
--define(CAP_OBJECT_FORMAT, app_helper:get_env(riak_kv, object_format, v1)).
+-define(CAP_OBJECT_FORMAT, v1).
 
 % -define(CAP_VCLOCK_ENCODING,
 %     riak_core_capability:get({riak_kv, vclock_data_encoding}, encode_zlib)

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -664,13 +664,13 @@
 
 %% @doc Controls which binary representation of a riak value is stored
 %% on disk.
-%% * 0: Original erlang:term_to_binary format. Higher space overhead.
+%% * 0: No longer supported.
 %% * 1: New format for more compact storage of small values.
-%% If using the leveled backend object_format 1 will always be used, when
-%% persisting data into the backend - even if 0 has been configured here
+%% This configuration will now be ignored as of Riak 3.4
 {mapping, "object.format", "riak_kv.object_format", [
   {default, 1},
-  {datatype, [{integer, 1}, {integer, 0}]}
+  {datatype, [{integer, 1}, {integer, 0}]},
+  hidden
 ]}.
 
 {translation, "riak_kv.object_format",

--- a/rebar.config
+++ b/rebar.config
@@ -44,7 +44,6 @@
     {sext, {git, "https://github.com/OpenRiak/sext.git", {branch, "openriak-3.2"}}},
     {riak_pipe, {git, "https://github.com/OpenRiak/riak_pipe.git", {branch, "openriak-3.4"}}},
     {riak_dt, {git, "https://github.com/OpenRiak/riak_dt.git", {branch, "openriak-3.2"}}},
-    {riak_pb, {git, "https://github.com/OpenRiak/riak_pb.git", {branch, "openriak-3.4"}}},
     {riak_api, {git, "https://github.com/OpenRiak/riak_api.git", {branch, "openriak-3.4"}}},
     {hyper, {git, "https://github.com/OpenRiak/hyper", {branch, "openriak-3.2"}}},
     {kv_index_tictactree, {git, "https://github.com/OpenRiak/kv_index_tictactree.git", {branch, "openriak-3.4"}}},

--- a/src/riak.erl
+++ b/src/riak.erl
@@ -184,7 +184,7 @@ client_test_phase1(Client) ->
 client_test_phase2(Client, Object0) ->
     Now = calendar:universal_time(),
     Object = riak_object:update_value(Object0, Now),
-    case riak_client:put(Object, 1, Client) of
+    case riak_client:put(Object, Client) of
         ok ->
             client_test_phase3(Client, Now);
         Error ->

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -27,6 +27,7 @@
 -export([new/2]).
 -export([get/3,get/4,get/5]).
 -export([put/2,put/3]).
+-export([put/4,put/5,put/6]).
 -export([delete/3,delete/4,delete/5,reap/3,reap/4]).
 -export([delete_vclock/4,delete_vclock/5,delete_vclock/6]).
 -export([list_keys/2,list_keys/3,list_keys/4]).
@@ -388,7 +389,7 @@ put(RObj, {?MODULE, [_Node, _ClientId]}=THIS) ->
     {error, {n_val_violation, N::integer()}} |
     {error, Err :: term()}.
 %% @doc Store RObj in the cluster.
-put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
+put(RObj, Options, {?MODULE, [Node, ClientId]}) when is_list(Options) ->
     Me = self(),
     ReqId = mk_reqid(),
     {Opts0, RObj0} =
@@ -398,7 +399,21 @@ put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
         ClientId ->
             {[asis|Options], riak_object:increment_vclock(RObj, ClientId)}
     end,
-    case riak_kv_put_fsm:start({raw, ReqId, Me}, RObj0, Opts0) of
+    R =
+        case node() of
+            Node ->
+                riak_kv_put_fsm:start({raw, ReqId, Me}, RObj0, Opts0);
+            _ ->
+                %% This is required when riak_test (or anything) calls
+                %% riak_client direct
+                proc_lib:spawn_link(
+                    Node,
+                    riak_kv_put_fsm,
+                    start_link,
+                    [{raw, ReqId, Me}, RObj, Options]
+                )
+        end,
+    case R of
         consistent ->
             consistent_put(RObj, Options, {?MODULE, [Node, ClientId]});
         write_once ->
@@ -406,7 +421,22 @@ put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
         _ ->
             Timeout = recv_timeout(Options),
             wait_for_reqid(ReqId, Timeout)
-    end.
+    end;
+%% @doc deprecated - but required in riak_test
+put(RObj, W, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    put(RObj, [{w, W}, {dw, W}], THIS).
+
+%% @doc deprecated - but required in riak_test
+put(RObj, W, DW, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    put(RObj, [{w, W}, {dw, DW}], THIS).
+
+%% @doc deprecated - but required in riak_test
+put(RObj, W, DW, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    put(RObj,  [{w, W}, {dw, DW}, {timeout, Timeout}], THIS).
+
+%% @doc deprecated - but required in riak_test
+put(RObj, W, DW, Timeout, Options, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    put(RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options], THIS).
 
 consistent_put(RObj, Options, {?MODULE, [Node, _ClientId]}) ->
     Bucket = riak_object:bucket(RObj),

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -26,7 +26,7 @@
 
 -export([new/2]).
 -export([get/3,get/4,get/5]).
--export([put/2,put/3,put/4,put/5,put/6]).
+-export([put/2,put/3]).
 -export([delete/3,delete/4,delete/5,reap/3,reap/4]).
 -export([delete_vclock/4,delete_vclock/5,delete_vclock/6]).
 -export([list_keys/2,list_keys/3,list_keys/4]).
@@ -377,36 +377,36 @@ get(Bucket, Key, R, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) when
 %%      Return as soon as the default W value number of nodes for this bucket
 %%      nodes have received the request.
 %% @equiv put(RObj, [])
-put(RObj, {?MODULE, [_Node, _ClientId]}=THIS) -> put(RObj, [], THIS).
+put(RObj, {?MODULE, [_Node, _ClientId]}=THIS) ->
+    put(RObj, [], THIS).
 
-
-normal_put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
+-spec put(riak_object:riak_object(), riak_kv_put_fsm:options(), riak_client()) ->
+    ok |
+    {ok, riak_object:riak_object()} |
+    {error, notfound} |
+    {error, timeout} |
+    {error, {n_val_violation, N::integer()}} |
+    {error, Err :: term()}.
+%% @doc Store RObj in the cluster.
+put(RObj, Options, {?MODULE, [Node, ClientId]}) ->
     Me = self(),
     ReqId = mk_reqid(),
+    {Opts0, RObj0} =
     case ClientId of
         undefined ->
-            case node() of
-                Node ->
-                    riak_kv_put_fsm:start({raw, ReqId, Me}, RObj, Options);
-                _ ->
-                    %% Still using the deprecated `start_link' alias for `start'
-                    %% here, in case the remote node is pre-2.2:
-                    proc_lib:spawn_link(Node, riak_kv_put_fsm, start_link,
-                                        [{raw, ReqId, Me}, RObj, Options])
-            end;
-        _ ->
-            UpdObj = riak_object:increment_vclock(RObj, ClientId),
-            case node() of
-                Node ->
-                    riak_kv_put_fsm:start_link({raw, ReqId, Me}, UpdObj, [asis|Options]);
-                _ ->
-                    proc_lib:spawn_link(Node, riak_kv_put_fsm, start_link,
-                                        [{raw, ReqId, Me}, RObj, [asis|Options]])
-            end
+            {Options, RObj};
+        ClientId ->
+            {[asis|Options], riak_object:increment_vclock(RObj, ClientId)}
     end,
-    %% TODO: Investigate adding a monitor here and eliminating the timeout.
-    Timeout = recv_timeout(Options),
-    wait_for_reqid(ReqId, Timeout).
+    case riak_kv_put_fsm:start({raw, ReqId, Me}, RObj0, Opts0) of
+        consistent ->
+            consistent_put(RObj, Options, {?MODULE, [Node, ClientId]});
+        write_once ->
+            write_once_put(Node, RObj, Options, {?MODULE, [Node, ClientId]});
+        _ ->
+            Timeout = recv_timeout(Options),
+            wait_for_reqid(ReqId, Timeout)
+    end.
 
 consistent_put(RObj, Options, {?MODULE, [Node, _ClientId]}) ->
     Bucket = riak_object:bucket(RObj),
@@ -449,84 +449,6 @@ consistent_put_type(RObj, Options) ->
             %% overwrite
             %% TODO: Expose client option to explicitly request overwrite
             put_once
-    end.
-
-%% @spec put(RObj :: riak_object:riak_object(), riak_kv_put_fsm:options(), riak_client()) ->
-%%       ok |
-%%       {ok, details()} |
-%%       {ok, riak_object:riak_object()} |
-%%       {ok, riak_object:riak_object(), details()} |
-%%       {error, notfound} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}} |
-%%       {error, Err :: term()} |
-%%       {error, Err :: term(), details()}
-%% @doc Store RObj in the cluster.
-put(RObj, Options, {?MODULE, [Node, _ClientId]}=THIS) when is_list(Options) ->
-    case consistent_object(Node, riak_object:bucket(RObj)) of
-        true ->
-            consistent_put(RObj, Options, THIS);
-        false ->
-            maybe_normal_put(RObj, Options, THIS);
-        {error,_}=Err ->
-            Err
-    end;
-
-%% @spec put(RObj :: riak_object:riak_object(), W :: integer(), riak_client()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
-%% @doc Store RObj in the cluster.
-%%      Return as soon as at least W nodes have received the request.
-%% @equiv put(RObj, [{w, W}, {dw, W}])
-put(RObj, W, {?MODULE, [_Node, _ClientId]}=THIS) -> put(RObj, [{w, W}, {dw, W}], THIS).
-
-%% @spec put(RObj::riak_object:riak_object(),W :: integer(),RW :: integer(), riak_client()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
-%% @doc Store RObj in the cluster.
-%%      Return as soon as at least W nodes have received the request, and
-%%      at least DW nodes have stored it in their storage backend.
-%% @equiv put(Robj, W, DW, default_timeout())
-put(RObj, W, DW, {?MODULE, [_Node, _ClientId]}=THIS) -> put(RObj, [{w, W}, {dw, DW}], THIS).
-
-%% @spec put(RObj::riak_object:riak_object(), W :: integer(), RW :: integer(),
-%%           TimeoutMillisecs :: integer(), riak_client()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
-%% @doc Store RObj in the cluster.
-%%      Return as soon as at least W nodes have received the request, and
-%%      at least DW nodes have stored it in their storage backend, or
-%%      TimeoutMillisecs passes.
-put(RObj, W, DW, Timeout, {?MODULE, [_Node, _ClientId]}=THIS) ->
-    put(RObj,  [{w, W}, {dw, DW}, {timeout, Timeout}], THIS).
-
-%% @spec put(RObj::riak_object:riak_object(), W :: integer(), RW :: integer(),
-%%           TimeoutMillisecs :: integer(), Options::list(), riak_client()) ->
-%%        ok |
-%%       {error, too_many_fails} |
-%%       {error, timeout} |
-%%       {error, {n_val_violation, N::integer()}}
-%% @doc Store RObj in the cluster.
-%%      Return as soon as at least W nodes have received the request, and
-%%      at least DW nodes have stored it in their storage backend, or
-%%      TimeoutMillisecs passes.
-put(RObj, W, DW, Timeout, Options, {?MODULE, [_Node, _ClientId]}=THIS) ->
-    put(RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options], THIS).
-
-maybe_normal_put(RObj, Options, {?MODULE, [Node, _ClientId]}=THIS) when is_list(Options) ->
-    case write_once(Node, riak_object:bucket(RObj)) of
-        true ->
-            write_once_put(Node, RObj, Options, THIS);
-        false ->
-            normal_put(RObj, Options, THIS);
-        {error,_}=Err ->
-            Err
     end.
 
 write_once_put(Node, RObj, Options, {?MODULE, [_Node, _ClientId]}) when Node =:= node()->
@@ -1231,18 +1153,6 @@ consistent_object(Node, Bucket) when Node =:= node() ->
     riak_kv_util:consistent_object(Bucket);
 consistent_object(Node, Bucket) ->
     case rpc:call(Node, riak_kv_util, consistent_object, [Bucket]) of
-        {badrpc, {'EXIT', {undef, _}}} ->
-            false;
-        {badrpc, _}=Err ->
-            {error, Err};
-        Result ->
-            Result
-    end.
-
-write_once(Node, Bucket) when Node =:= node() ->
-    riak_kv_util:get_write_once(Bucket);
-write_once(Node, Bucket) ->
-    case rpc:call(Node, riak_kv_util, get_write_once, [Bucket]) of
         {badrpc, {'EXIT', {undef, _}}} ->
             false;
         {badrpc, _}=Err ->

--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -254,18 +254,7 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key},
                                   options=Options,
                                   trace=Trace}) ->
     ?DTRACE(Trace, ?C_GET_FSM_PREPARE, [], ["prepare"]),
-    {ok, DefaultProps} = application:get_env(riak_core,
-                                             default_bucket_props),
-    BucketProps = riak_core_bucket:get_bucket(Bucket),
-    %% typed buckets never fall back to defaults
-    Props =
-        case is_tuple(Bucket) of
-            false ->
-                lists:keymerge(1, lists:keysort(1, BucketProps),
-                               lists:keysort(1, DefaultProps));
-            true ->
-                BucketProps
-        end,
+    BucketProps = riak_kv_util:get_bucket_props(Bucket),
     DocIdx = riak_core_util:chash_key(BKey, BucketProps),
     Bucket_N = get_option(n_val, BucketProps),
     CrdtOp = get_option(crdt_op, Options),
@@ -298,7 +287,7 @@ prepare(timeout, StateData=#state{bkey=BKey={Bucket,_Key},
                                 StateData#state{
                                             starttime=riak_core_util:moment(),
                                             n = N,
-                                            bucket_props=Props,
+                                            bucket_props=BucketProps,
                                             preflist2 = Preflist2,
                                             tracked_bucket = StatTracked,
                                             crdt_op = CrdtOp,
@@ -733,10 +722,14 @@ read_repair(GetCoreIndices, RepairObj,
         _ ->
             ok
     end,
-    riak_kv_vnode:readrepair(DocIdxList, BKey, RepairObj, ReqId,
-                             StartTime, [{returnbody, false},
-                                         {bucket_props, BucketProps},
-                                         {crdt_op, CrdtOp}]),
+    riak_kv_vnode:readrepair(
+        DocIdxList,
+        BKey,
+        RepairObj,
+        ReqId,
+        StartTime, 
+        [{returnbody, false}, {bucket_props, BucketProps}, {crdt_op, CrdtOp}]
+    ),
     ok = riak_kv_stat:update({read_repairs, RepairPreflist}).
 
 -spec read_repair_index(

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -128,8 +128,7 @@ log(Type, JobID, Attempts, Aborts, Queue) ->
 
     ?LOG_INFO(
         lists:flatten(
-            ["~p job_id=~p has ",
-                "attempts=~w aborts=~w ",
+            ["~w job_id=~w has attempts=~w aborts=~w ",
                 QueueLengths,
                 OverflowLengths,
                 DiscardCounts]),

--- a/src/riak_kv_put_core.erl
+++ b/src/riak_kv_put_core.erl
@@ -92,14 +92,42 @@ add_result({w, Idx, _ReqId}, PutCore = #putcore{results = Results,
                                                 num_w = NumW}) ->
     PutCore#putcore{results = [{Idx, w} | Results],
                     num_w = NumW + 1};
-add_result({dw, Idx, _ReqId}, PutCore = #putcore{results = Results,
-                                                 num_dw = NumDW}) ->
-    num_node_confirms(num_pw(PutCore#putcore{results = [{Idx, {dw, undefined}} | Results],
-                    num_dw = NumDW + 1}, Idx));
-add_result({dw, Idx, ResObj, _ReqId}, PutCore = #putcore{results = Results,
-                                                         num_dw = NumDW}) ->
-    num_node_confirms(num_pw(PutCore#putcore{results = [{Idx, {dw, ResObj}} | Results],
-                    num_dw = NumDW + 1}, Idx));
+add_result(
+    {dw, Idx, _ReqId},
+    PutCore =
+        #putcore{results = Results, num_dw = NumDW, node_confirms = NCR}
+    ) ->
+    UpdatedCorePW =
+        num_pw(
+            PutCore#putcore{
+                results = [{Idx, {dw, undefined}} | Results],
+                num_dw = NumDW + 1},
+            Idx
+        ),
+    case NCR of
+        NCR when is_integer(NCR), NCR > 0 ->
+            num_node_confirms(UpdatedCorePW);
+        _ ->
+            UpdatedCorePW
+    end;
+add_result(
+    {dw, Idx, ResObj, _ReqId},
+    PutCore =
+        #putcore{results = Results, num_dw = NumDW, node_confirms = NCR}
+    ) ->
+    UpdatedCorePW =
+        num_pw(
+            PutCore#putcore{
+                results = [{Idx, {dw, ResObj}} | Results],
+                num_dw = NumDW + 1},
+            Idx
+        ),
+    case NCR of
+        NCR when is_integer(NCR), NCR > 0 ->
+            num_node_confirms(UpdatedCorePW);
+        _ ->
+            UpdatedCorePW
+    end;
 add_result({fail, Idx, _ReqId}, PutCore = #putcore{results = Results,
                                                    num_fail = NumFail}) ->
     PutCore#putcore{results = [{Idx, {error, undefined}} | Results],
@@ -234,15 +262,19 @@ num_pw(PutCore = #putcore{num_pw=NumPW, idx_type=IdxType}, Idx) ->
 -spec count_diverse_nodes(IDXType::idx_type(), [idxresult()]) -> non_neg_integer().
 count_diverse_nodes(IdxType, Results) ->
     DWrites = [Part || {Part, {dw, _}} <- Results ],
-    count_physically_diverse(IdxType, DWrites, []).
-
--spec count_physically_diverse(IDXType::idx_type(), [non_neg_integer()], [node()]) -> non_neg_integer().
-count_physically_diverse(_IdxType, [], NodeAcc) ->
-    UniqueNodes = lists:usort(NodeAcc),
-    length(UniqueNodes);
-count_physically_diverse(IdxType, [DWPart | DWRest], NodeAcc) ->
-    {DWPart, _Type, Node} = lists:keyfind(DWPart, 1, IdxType),
-    count_physically_diverse(IdxType, DWRest, [Node | NodeAcc]).
+    Nodes =
+        lists:filtermap(
+                fun({DWPart, _Type, Node}) ->
+                    case lists:member(DWPart, DWrites) of
+                        true ->
+                            {true, Node};
+                        false ->
+                            false
+                    end
+                end,
+                IdxType
+            ),
+    length(lists:usort(Nodes)).
 
 %% @private Return number of physically diverse partitions in results
 -spec num_node_confirms(putcore()) -> putcore().

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -128,8 +128,7 @@
                 allowmult = true :: boolean(),
                 precommit=[] :: list(),
                 postcommit=[] :: list(),
-                bucket_props_map :: #{atom() => any()},
-                bucket_props_list :: list({atom(),any()}),
+                bucket_props :: list({atom(),any()}),
                 putcore :: riak_kv_put_core:putcore() | undefined,
                 timing = [] :: [{atom(), {non_neg_integer(), non_neg_integer(),
                                           non_neg_integer()}}],
@@ -156,17 +155,16 @@
         consistent|write_once|{ok, pid()}|{error, overload}.
 start(From, RObj, PutOptions) ->
     Bucket = riak_object:bucket(RObj),
-    BucketPropsL = riak_kv_util:get_bucket_props(Bucket),
-    BucketPropsM = maps:from_list(BucketPropsL),
+    BucketProps = riak_kv_util:get_bucket_props(Bucket),
     case {
-        maps:get(consistent, BucketPropsM, false),
-        maps:get(write_once, BucketPropsM, false)} of
+        get_option(consistent, BucketProps, false),
+        get_option(write_once, BucketProps, false)} of
         {true, _} ->
             consistent;
         {false, true} ->
             write_once;
         _ ->
-            Args = [From, RObj, PutOptions, Bucket, BucketPropsM, BucketPropsL],
+            Args = [From, RObj, PutOptions, Bucket, BucketProps],
             StartSideJob =
                 sidejob_supervisor:start_child(
                     riak_kv_put_fsm_sj, gen_fsm, start_link, [?MODULE, Args, []]
@@ -249,14 +247,13 @@ monitor_remote_coordinator(true = _UseAckP, MiddleMan, CoordNode, StateData) ->
 %% As test, but linked to the caller
 test_link(From, Object, PutOptions, StateProps) ->
     Bucket = riak_object:bucket(Object),
-    {bucket_props_list, BProps} =
-        lists:keyfind(bucket_props_list, 1, StateProps),
-    BucketPropsM = maps:from_list(BProps),
+    {bucket_props, BProps} =
+        lists:keyfind(bucket_props, 1, StateProps),
     gen_fsm:start_link(
         ?MODULE,
         {
             test,
-            [From, Object, PutOptions, Bucket, BucketPropsM, BProps],
+            [From, Object, PutOptions, Bucket, BProps],
             StateProps
         },
         []
@@ -270,7 +267,7 @@ test_link(From, Object, PutOptions, StateProps) ->
 %% ====================================================================
 
 %% @private
-init([From, RObj, Options0, Bucket, BucketPropsM, BucketPropsL]) ->
+init([From, RObj, Options0, Bucket, BucketPropsL]) ->
     Key = riak_object:key(RObj),
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     Options = proplists:unfold(Options0),
@@ -282,8 +279,7 @@ init([From, RObj, Options0, Bucket, BucketPropsM, BucketPropsL]) ->
             trace = Trace,
             options = Options,
             timing = riak_kv_fsm_timing:add_timing(prepare, []),
-            bucket_props_map = BucketPropsM,
-            bucket_props_list = BucketPropsL
+            bucket_props = BucketPropsL
         },
     gen_fsm:send_event(self(), timeout),
     case Trace of
@@ -328,7 +324,7 @@ prepare(
         State=#state{
             bkey = {Bucket, Key},
             options=Options,
-            bucket_props_map=BucketProps
+            bucket_props=BucketProps
         }
     ) ->
     StatTracked = get_option(stat_tracked, BucketProps, false),
@@ -370,8 +366,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                                       options = Options,
                                       robj = RObj0,
                                       n=N,
-                                      bucket_props_map = BucketProps,
-                                      bucket_props_list = LegacyProps,
+                                      bucket_props = BucketProps,
                                       trace = Trace,
                                       preflist2 = Preflist2}) ->
     
@@ -432,12 +427,12 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                 case {ReturnBody, Postcommit} of
                     {false, []} ->
                         [
-                            {bucket_props, LegacyProps}
+                            {bucket_props, BucketProps}
                         ];
                     _ ->
                         [
                             {returnbody, true},
-                            {bucket_props, LegacyProps}
+                            {bucket_props, BucketProps}
                         ]
                 end,
             RObj = apply_updates(RObj0, ULM),
@@ -449,7 +444,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                             vclock:prune(
                                 Clock,
                                 riak_core_util:moment(),
-                                LegacyProps
+                                BucketProps
                             ),
                         case {length(MaybePrunedClock), length(Clock)} of
                             {PVL, UPVL} when PVL < UPVL ->
@@ -1091,15 +1086,13 @@ get_hooks(postcommit, BucketProps, State) ->
     CondHooks =
         riak_kv_hooks:get_conditional_postcommit(
             State#state.bkey,
-            State#state.bucket_props_list
+            State#state.bucket_props
         ),
     BaseHooks ++ (CondHooks -- BaseHooks).
 
 get_option(Name, Options) ->
     get_option(Name, Options, undefined).
 
-get_option(Name, Options, Default) when is_map(Options) ->
-    maps:get(Name, Options, Default);
 get_option(Name, Options, Default) ->
     case lists:keyfind(Name, 1, Options) of
         {_, Val} ->
@@ -1188,7 +1181,7 @@ get_preflist({error, _Reason}=Err, _SQ, _AI, _MC, State) ->
     process_reply(Err, State);
 get_preflist(N, SQ, AI, MC, State) ->
     #state{bkey = BKey,
-           bucket_props_list=BucketProps,
+           bucket_props=BucketProps,
            bad_coordinators = BadCoordinators} = State,
 
     DocIdx = riak_core_util:chash_key(BKey, BucketProps),

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -146,8 +146,8 @@
 
 -spec start(
     {raw, non_neg_integer(), pid()},
-    riak_object:object(),
-    proplist:proplist()) ->
+    riak_object:riak_object(),
+    proplists:proplist()) ->
         consistent|write_once|{ok, pid()}|{error, overload}.
 start(From, RObj, PutOptions) ->
     Bucket = riak_object:bucket(RObj),

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -35,8 +35,6 @@
 
 -behaviour(gen_fsm).
 -export([start/3, start_link/3]).
--export([set_put_coordinator_failure_timeout/1,
-         get_put_coordinator_failure_timeout/0]).
 -ifdef(TEST).
 -export([test_link/4]).
 -endif.
@@ -133,14 +131,14 @@
                 reply, % reply sent to client,
                 trace = false :: boolean(), 
                 tracked_bucket=false :: boolean(), %% track per bucket stats
-                bad_coordinators = [] :: [atom()],
-                coordinator_timeout :: integer()
+                bad_coordinators = [] :: [atom()]
                }).
 
 -include("riak_kv_dtrace.hrl").
 
 -define(PARSE_INDEX_PRECOMMIT, {struct, [{<<"mod">>, <<"riak_index">>}, {<<"fun">>, <<"parse_object_hook">>}]}).
 -define(DEFAULT_TIMEOUT, 60000).
+-define(MIN_COORD_TIMEOUT, 3000).
 
 %% ===================================================================
 %% Public API
@@ -176,20 +174,11 @@ start(From, RObj, PutOptions) ->
     end.
 
 %% Included for backward compatibility, in case someone is, say, passing around
-%% a riak_client instace between nodes during a rolling upgrade. The old
+%% a riak_client instance between nodes during a rolling upgrade. The old
 %% `start_link' function has been renamed `start' since it doesn't actually link
 %% to the caller.
 start_link(From, Object, PutOptions) -> start(From, Object, PutOptions).
 
-set_put_coordinator_failure_timeout(MS) when is_integer(MS), MS >= 0 ->
-    application:set_env(riak_kv, put_coordinator_failure_timeout, MS);
-set_put_coordinator_failure_timeout(Bad) ->
-    ?LOG_ERROR("~s:set_put_coordinator_failure_timeout(~p) invalid",
-                [?MODULE, Bad]),
-    set_put_coordinator_failure_timeout(3000).
-
-get_put_coordinator_failure_timeout() ->
-    app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000).
 
 make_ack_options(Options) ->
     AckOption = get_option(ack_execute, Options),
@@ -219,6 +208,7 @@ spawn_coordinator_proc(CoordNode, Mod, Fun, Args) ->
 monitor_remote_coordinator(false = _UseAckP, _MiddleMan, _CoordNode, StateData) ->
     {stop, normal, StateData};
 monitor_remote_coordinator(true = _UseAckP, MiddleMan, CoordNode, StateData) ->
+    TO = app_helper:get_env(riak_kv, put_coordinator_failure_timeout, 3000),
     receive
         {ack, CoordNodeFinal, now_executing} ->
             case CoordNodeFinal of
@@ -229,7 +219,7 @@ monitor_remote_coordinator(true = _UseAckP, MiddleMan, CoordNode, StateData) ->
                                   [CoordNodeFinal, CoordNode])
             end,
             {stop, normal, StateData}
-    after StateData#state.coordinator_timeout ->
+    after TO ->
             exit(MiddleMan, kill),
             Bad = StateData#state.bad_coordinators,
             ?LOG_WARNING("timed out waiting for forward-ack, adding ~p to bad coordinators",
@@ -269,7 +259,6 @@ test_link(From, Object, PutOptions, StateProps) ->
 %% @private
 init([From, RObj, Options0, Bucket, BucketProps]) ->
     Key = riak_object:key(RObj),
-    CoordTimeout = get_put_coordinator_failure_timeout(),
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     Options = proplists:unfold(Options0),
     StateData =
@@ -280,7 +269,6 @@ init([From, RObj, Options0, Bucket, BucketProps]) ->
             trace = Trace,
             options = Options,
             timing = riak_kv_fsm_timing:add_timing(prepare, []),
-            coordinator_timeout=CoordTimeout,
             bucket_props = BucketProps
         },
     gen_fsm:send_event(self(), timeout),

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -128,7 +128,8 @@
                 allowmult = true :: boolean(),
                 precommit=[] :: list(),
                 postcommit=[] :: list(),
-                bucket_props :: list({atom(),any()}),
+                bucket_props_map :: #{atom() => any()},
+                bucket_props_list :: list({atom(),any()}),
                 putcore :: riak_kv_put_core:putcore() | undefined,
                 timing = [] :: [{atom(), {non_neg_integer(), non_neg_integer(),
                                           non_neg_integer()}}],
@@ -155,16 +156,17 @@
         consistent|write_once|{ok, pid()}|{error, overload}.
 start(From, RObj, PutOptions) ->
     Bucket = riak_object:bucket(RObj),
-    BucketProps = riak_kv_util:get_bucket_props(Bucket),
+    BucketPropsL = riak_kv_util:get_bucket_props(Bucket),
+    BucketPropsM = maps:from_list(BucketPropsL),
     case {
-        get_option(consistent, BucketProps, false),
-        get_option(write_once, BucketProps, false)} of
+        maps:get(consistent, BucketPropsM, false),
+        maps:get(write_once, BucketPropsM, false)} of
         {true, _} ->
             consistent;
         {false, true} ->
             write_once;
         _ ->
-            Args = [From, RObj, PutOptions, Bucket, BucketProps],
+            Args = [From, RObj, PutOptions, Bucket, BucketPropsM, BucketPropsL],
             StartSideJob =
                 sidejob_supervisor:start_child(
                     riak_kv_put_fsm_sj, gen_fsm, start_link, [?MODULE, Args, []]
@@ -247,13 +249,14 @@ monitor_remote_coordinator(true = _UseAckP, MiddleMan, CoordNode, StateData) ->
 %% As test, but linked to the caller
 test_link(From, Object, PutOptions, StateProps) ->
     Bucket = riak_object:bucket(Object),
-    {bucket_props, BProps} =
-        lists:keyfind(bucket_props, 1, StateProps),
+    {bucket_props_list, BProps} =
+        lists:keyfind(bucket_props_list, 1, StateProps),
+    BucketPropsM = maps:from_list(BProps),
     gen_fsm:start_link(
         ?MODULE,
         {
             test,
-            [From, Object, PutOptions, Bucket, BProps],
+            [From, Object, PutOptions, Bucket, BucketPropsM, BProps],
             StateProps
         },
         []
@@ -267,7 +270,7 @@ test_link(From, Object, PutOptions, StateProps) ->
 %% ====================================================================
 
 %% @private
-init([From, RObj, Options0, Bucket, BucketPropsL]) ->
+init([From, RObj, Options0, Bucket, BucketPropsM, BucketPropsL]) ->
     Key = riak_object:key(RObj),
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     Options = proplists:unfold(Options0),
@@ -279,7 +282,8 @@ init([From, RObj, Options0, Bucket, BucketPropsL]) ->
             trace = Trace,
             options = Options,
             timing = riak_kv_fsm_timing:add_timing(prepare, []),
-            bucket_props = BucketPropsL
+            bucket_props_map = BucketPropsM,
+            bucket_props_list = BucketPropsL
         },
     gen_fsm:send_event(self(), timeout),
     case Trace of
@@ -324,7 +328,7 @@ prepare(
         State=#state{
             bkey = {Bucket, Key},
             options=Options,
-            bucket_props=BucketProps
+            bucket_props_map=BucketProps
         }
     ) ->
     StatTracked = get_option(stat_tracked, BucketProps, false),
@@ -366,7 +370,8 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                                       options = Options,
                                       robj = RObj0,
                                       n=N,
-                                      bucket_props = BucketProps,
+                                      bucket_props_map = BucketProps,
+                                      bucket_props_list = LegacyProps,
                                       trace = Trace,
                                       preflist2 = Preflist2}) ->
     
@@ -427,12 +432,12 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                 case {ReturnBody, Postcommit} of
                     {false, []} ->
                         [
-                            {bucket_props, BucketProps}
+                            {bucket_props, LegacyProps}
                         ];
                     _ ->
                         [
                             {returnbody, true},
-                            {bucket_props, BucketProps}
+                            {bucket_props, LegacyProps}
                         ]
                 end,
             RObj = apply_updates(RObj0, ULM),
@@ -444,7 +449,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                             vclock:prune(
                                 Clock,
                                 riak_core_util:moment(),
-                                BucketProps
+                                LegacyProps
                             ),
                         case {length(MaybePrunedClock), length(Clock)} of
                             {PVL, UPVL} when PVL < UPVL ->
@@ -1086,13 +1091,15 @@ get_hooks(postcommit, BucketProps, State) ->
     CondHooks =
         riak_kv_hooks:get_conditional_postcommit(
             State#state.bkey,
-            State#state.bucket_props
+            State#state.bucket_props_list
         ),
     BaseHooks ++ (CondHooks -- BaseHooks).
 
 get_option(Name, Options) ->
     get_option(Name, Options, undefined).
 
+get_option(Name, Options, Default) when is_map(Options) ->
+    maps:get(Name, Options, Default);
 get_option(Name, Options, Default) ->
     case lists:keyfind(Name, 1, Options) of
         {_, Val} ->
@@ -1181,7 +1188,7 @@ get_preflist({error, _Reason}=Err, _SQ, _AI, _MC, State) ->
     process_reply(Err, State);
 get_preflist(N, SQ, AI, MC, State) ->
     #state{bkey = BKey,
-           bucket_props=BucketProps,
+           bucket_props_list=BucketProps,
            bad_coordinators = BadCoordinators} = State,
 
     DocIdx = riak_core_util:chash_key(BKey, BucketProps),

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -34,8 +34,7 @@
                 {gen_fsm, send_event, 2}]}).
 
 -behaviour(gen_fsm).
--define(DEFAULT_OPTS, [{returnbody, false}, {update_last_modified, true}]).
--export([start/3]).
+-export([start/3, start_link/3]).
 -export([set_put_coordinator_failure_timeout/1,
          get_put_coordinator_failure_timeout/0]).
 -ifdef(TEST).
@@ -65,7 +64,7 @@
         {dw, non_neg_integer()} |
         {timeout, timeout()} |
         %% Prevent precommit/postcommit hooks from running
-        disable_hooks |
+        {disable_hooks, boolean()} |
         %% Request additional details about request added as extra
         %% element at the end of result tuple
         {details, detail()} |
@@ -73,7 +72,7 @@
         {sync_on_write, atom()} |
         %% Put the value as-is, do not increment the vclocks
         %% to make the value a frontier.
-        asis |
+        {asis, boolean()} |
         %% Use a sloppy quorum, default = true
         {sloppy_quorum, boolean()} |
         %% The N value, default = value from bucket properties
@@ -91,7 +90,10 @@
         %% it.
         {mbox_check, boolean()} |
         {counter_op, any()} |
-        {crdt_op, any()}.
+        {crdt_op, any()} |
+        {node_confirms, non_neg_integer()} |
+        {returnbody, boolean()} |
+        {update_last_modified, boolean()}.
 
 -type options() :: [option()].
 
@@ -151,7 +153,7 @@
         consistent|write_once|{ok, pid()}|{error, overload}.
 start(From, RObj, PutOptions) ->
     Bucket = riak_object:bucket(RObj),
-    BucketProps = get_bucket_props(Bucket),
+    BucketProps = riak_kv_util:get_bucket_props(Bucket),
     case {lists:member({consistent, true}, BucketProps),
             lists:member({write_once, true}, BucketProps)} of
         {true, _} ->
@@ -172,6 +174,12 @@ start(From, RObj, PutOptions) ->
                     {ok, Pid}
             end
     end.
+
+%% Included for backward compatibility, in case someone is, say, passing around
+%% a riak_client instace between nodes during a rolling upgrade. The old
+%% `start_link' function has been renamed `start' since it doesn't actually link
+%% to the caller.
+start_link(From, Object, PutOptions) -> start(From, Object, PutOptions).
 
 set_put_coordinator_failure_timeout(MS) when is_integer(MS), MS >= 0 ->
     application:set_env(riak_kv, put_coordinator_failure_timeout, MS);
@@ -244,7 +252,7 @@ monitor_remote_coordinator(true = _UseAckP, MiddleMan, CoordNode, StateData) ->
 %% As test, but linked to the caller
 test_link(From, Object, PutOptions, StateProps) ->
     Bucket = riak_object:bucket(Object),
-    BucketProps = get_bucket_props(Bucket),
+    BucketProps = riak_kv_util:get_bucket_props(Bucket),
     gen_fsm:start_link(
         ?MODULE,
         {test, [From, Object, PutOptions, Bucket, BucketProps], StateProps},
@@ -355,22 +363,19 @@ prepare(
 
 %% @private
 validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
-                                      options = Options0,
+                                      options = Options,
                                       robj = RObj0,
                                       n=N, bucket_props = BucketProps,
                                       trace = Trace,
                                       preflist2 = Preflist2}) ->
-    Timeout = get_option(timeout, Options0, ?DEFAULT_TIMEOUT),
-    PW0 = get_option(pw, Options0, default),
-    NodeConfirms0 = get_option(node_confirms, Options0, default),
-    W0 = get_option(w, Options0, default),
-    DW0 = get_option(dw, Options0, default),
-    SyncOnWrite0 = get_option(sync_on_write, Options0, default),
+    
+    {Timeout, PW0, NC0, W0, DW0, SW0, Disable, ReturnBody, Asis, ULM} =
+        get_options_for_validate(Options),
 
     PW = riak_kv_util:expand_rw_value(pw, PW0, BucketProps, N),
-    NodeConfirms = riak_kv_util:expand_rw_value(node_confirms, NodeConfirms0, BucketProps, N),
+    NodeConfirms = riak_kv_util:expand_rw_value(node_confirms, NC0, BucketProps, N),
     W = riak_kv_util:expand_rw_value(w, W0, BucketProps, N),
-    SyncOnWrite = riak_kv_util:expand_sync_on_write(SyncOnWrite0, BucketProps),
+    SyncOnWrite = riak_kv_util:expand_sync_on_write(SW0, BucketProps),
 
     %% Expand the DW value, but also ensure that DW <= W
     DW1 = riak_kv_util:expand_rw_value(dw, DW0, BucketProps, N),
@@ -393,7 +398,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
         PW =:= error ->
             process_reply({error, {pw_val_violation, PW0}}, StateData0);
         NodeConfirms =:= error ->
-            process_reply({error, {node_confirms_val_violation, NodeConfirms0}}, StateData0);
+            process_reply({error, {node_confirms_val_violation, NC0}}, StateData0);
         W =:= error ->
             process_reply({error, {w_val_violation, W0}}, StateData0);
         DW =:= error ->
@@ -407,8 +412,6 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                                    need, MinVnodes}}, StateData0);
         true ->
             AllowMult = get_option(allow_mult, BucketProps),
-            Options = flatten_options(Options0 ++ ?DEFAULT_OPTS, []),
-            Disable = get_option(disable_hooks, Options),
             Precommit =
                 if Disable -> [];
                    true ->
@@ -419,26 +422,24 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                 if Disable -> [];
                    true -> get_hooks(postcommit, BucketProps, StateData0)
                 end,
-            {VNodeOpts0, ReturnBody} =
-                case get_option(returnbody, Options) of
-                    true ->
-                        {[], true};
+            InitVNodeOpts =
+                case {ReturnBody, Postcommit} of
+                    {false, []} ->
+                        [{bucket_props, BucketProps}];
                     _ ->
-                        case Postcommit of
-                            [] -> 
-                                {[], false};
-                            _ -> 
-                                {[{returnbody,true}], false}
-                        end
+                        [{returnbody, true}, {bucket_props, BucketProps}]
                 end,
-            RObj = apply_updates(RObj0, Options),
+            RObj = apply_updates(RObj0, ULM),
             RR =
-                case get_option(asis, Options) of
+                case Asis of
                     true ->
                         Clock = riak_object:vclock(RObj),
                         MaybePrunedClock =
                             vclock:prune(
-                                Clock, riak_core_util:moment(), BucketProps),
+                                Clock,
+                                riak_core_util:moment(),
+                                BucketProps
+                            ),
                         case {length(MaybePrunedClock), length(Clock)} of
                             {PVL, UPVL} when PVL < UPVL ->
                                 true;
@@ -465,7 +466,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
             VNodeOpts =
                 handle_options(
                     Options3,
-                    [{bucket_props, BucketProps}|VNodeOpts0]
+                    InitVNodeOpts
                 ),
             StateData =
                 StateData0#state{
@@ -492,9 +493,9 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
             end
     end.
 
-apply_updates(RObj0, Options) ->
+apply_updates(RObj0, ULM) ->
     RObj1 = 
-        case get_option(update_last_modified, Options) of
+        case ULM of
             true ->
                 riak_object:update_last_modified(RObj0);
             _ ->
@@ -756,6 +757,96 @@ code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
 %% Internal functions
 %% ====================================================================
 
+
+-type w_param() :: backend|one|quorum|all|default|non_neg_integer()|binary().
+
+-spec get_options_for_validate(list(option()))->
+    {
+        pos_integer(),
+        w_param(), w_param(), w_param(), w_param(), w_param(),
+        boolean(), boolean(), boolean(), boolean()
+    }.
+get_options_for_validate(Options) ->
+    get_validate_options(
+        Options,
+        ?DEFAULT_TIMEOUT,
+        default, default, default, default, default,
+        false, false, false, true
+    ).
+
+get_validate_options([], TO, PW, NC, W, DW, SW, DH, RB, AI, UM) ->
+    {TO, PW, NC, W, DW, SW, DH, RB, AI, UM};
+get_validate_options(
+    [{timeout, TO}|RestOpts],
+    _TO,
+    PW, NC, W, DW, SW, DH, RB, AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{pw, PW}|RestOpts],
+    TO,
+    _PW,
+    NC, W, DW, SW, DH, RB, AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{node_confirms, NC}|RestOpts],
+    TO, PW,
+    _NC,
+    W, DW, SW, DH, RB, AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{w, W}|RestOpts],
+    TO, PW, NC,
+    _W,
+    DW, SW, DH, RB, AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{dw, DW}|RestOpts],
+    TO, PW, NC, W,
+    _DW,
+    SW, DH, RB, AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{sync_on_write, SW}|RestOpts],
+    TO, PW, NC, W, DW,
+    _SW,
+    DH, RB, AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{disable_hooks, DH}|RestOpts],
+    TO, PW, NC, W, DW, SW,
+    _DH,
+    RB, AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{returnbody, RB}|RestOpts],
+    TO, PW, NC, W, DW, SW, DH,
+    _RB,
+    AI, UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{asis, AI}|RestOpts],
+    TO, PW, NC, W, DW, SW, DH, RB,
+    _AI,
+    UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options(
+    [{update_last_modified, UM}|RestOpts],
+    TO, PW, NC, W, DW, SW, DH, RB, AI,
+    _UM
+) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM);
+get_validate_options([_Opt|RestOpts], TO, PW, NC, W, DW, SW, DH, RB, AI, UM) ->
+    get_validate_options(RestOpts, TO, PW, NC, W, DW, SW, DH, RB, AI, UM).
+
 %% Move to the new state, marking the time it started
 new_state(StateName, StateData=#state{trace = true}) ->
     {next_state, StateName, add_timing(StateName, StateData)};
@@ -812,27 +903,9 @@ process_reply(Reply, StateData = #state{postcommit = PostCommit,
     end.
 
 
-%%
-%% Given an expanded proplist of options, take the first entry for any given key
-%% and ignore the rest
-%%
-%% @private
-flatten_options([], Opts) ->
-    Opts;
-flatten_options([{Key, Value} | Rest], Opts) ->
-    case lists:keymember(Key, 1, Opts) of
-        true ->
-            flatten_options(Rest, Opts);
-        false ->
-            flatten_options(Rest, [{Key, Value} | Opts])
-    end.
-
 %% @private
 handle_options([], Acc) ->
     Acc;
-handle_options([{returnbody, true}|T], Acc) ->
-    VNodeOpts = [{returnbody, true} | Acc],
-    handle_options(T, VNodeOpts);
 handle_options([{sync_on_write, Val}|T], Acc) ->
     VNodeOpts = [{sync_on_write, Val} | Acc],
     handle_options(T, VNodeOpts);
@@ -986,18 +1059,17 @@ client_reply(Reply, State = #state{from = {raw, ReqId, Pid},
                                    timing = Timing0,
                                    options = Options}) ->
     Timing = riak_kv_fsm_timing:add_timing(reply, Timing0),
-    Reply2 = case get_option(details, Options, false) of
-                 false ->
-                     Reply;
-                 [] ->
-                     Reply;
-                 Details ->
-                     add_client_info(Reply, Details, 
-                                     State#state{timing = Timing})
-             end,
+    Reply2 =
+        case get_option(details, Options, false) of
+            false ->
+                Reply;
+            [] ->
+                Reply;
+            Details ->
+                add_client_info(Reply, Details, State#state{timing = Timing})
+        end,
     Pid ! {ReqId, Reply2},
-    State#state{reply = Reply, 
-                timing = Timing}.
+    State#state{reply = Reply, timing = Timing}.
 
 add_client_info(Reply, Details, State) ->
     Info = client_info(Details, State, []),
@@ -1037,21 +1109,6 @@ dtrace_errstr(Term) ->
 %% This function is for dbg tracing purposes
 late_put_fsm_coordinator_ack(_Node) ->
     ok.
-
--spec get_bucket_props(riak_object:bucket()) -> list().
-get_bucket_props(Bucket) ->
-    {ok, DefaultProps} = application:get_env(riak_core, default_bucket_props),
-    BucketProps = riak_core_bucket:get_bucket(Bucket),
-    %% typed buckets never fall back to defaults
-    case is_tuple(Bucket) of
-        false ->
-            lists:keymerge(
-                1,
-                lists:keysort(1, BucketProps),
-                lists:keysort(1, DefaultProps));
-        true ->
-            BucketProps
-    end.
 
 %% @private decide on the N Val for the put request, and error if
 %% there is a violation.
@@ -1455,15 +1512,13 @@ get_bucket_props_test_() ->
           begin
               Bucket = <<"bucket">>,
               %% amazing, not a ukeymerge
-              Props = get_bucket_props(Bucket),
+              Props = riak_kv_util:get_bucket_props(Bucket),
               %% i.e. a merge with defaults
               ?assertEqual([
                             {bprop1,bval1},
                             {bprop2,bval2},
                             {prop1,val1},
-                            {prop1,val1},
                             {prop2,bval9},
-                            {prop2,val2},
                             {prop3,val3}
                            ], Props)
           end)
@@ -1472,7 +1527,7 @@ get_bucket_props_test_() ->
        ?_test(
           begin
               Bucket = {<<"type">>, <<"bucket">>},
-              Props = get_bucket_props(Bucket),
+              Props = riak_kv_util:get_bucket_props(Bucket),
               %% i.e. no merge with defaults
               ?assertEqual(BucketProps, Props)
           end

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -94,6 +94,10 @@
         {update_last_modified, boolean()}.
 
 -type options() :: [option()].
+-type condition_check() ::
+    false|
+    {undefined, true, list()}|
+    {{true, vclock:vclock()}, undefined, list()}.
 
 -type preflist_entry() :: {Idx::non_neg_integer(), node()}.
 %% the information about vnode mailbox queues used to select a
@@ -124,21 +128,22 @@
                 allowmult = true :: boolean(),
                 precommit=[] :: list(),
                 postcommit=[] :: list(),
-                bucket_props :: list() | undefined,
+                bucket_props_map :: #{atom() => any()},
+                bucket_props_list :: list({atom(),any()}),
                 putcore :: riak_kv_put_core:putcore() | undefined,
                 timing = [] :: [{atom(), {non_neg_integer(), non_neg_integer(),
                                           non_neg_integer()}}],
                 reply, % reply sent to client,
                 trace = false :: boolean(), 
                 tracked_bucket=false :: boolean(), %% track per bucket stats
-                bad_coordinators = [] :: [atom()]
+                bad_coordinators = [] :: [atom()],
+                client_details = false :: detail()
                }).
 
 -include("riak_kv_dtrace.hrl").
 
 -define(PARSE_INDEX_PRECOMMIT, {struct, [{<<"mod">>, <<"riak_index">>}, {<<"fun">>, <<"parse_object_hook">>}]}).
 -define(DEFAULT_TIMEOUT, 60000).
--define(MIN_COORD_TIMEOUT, 3000).
 
 %% ===================================================================
 %% Public API
@@ -151,15 +156,17 @@
         consistent|write_once|{ok, pid()}|{error, overload}.
 start(From, RObj, PutOptions) ->
     Bucket = riak_object:bucket(RObj),
-    BucketProps = riak_kv_util:get_bucket_props(Bucket),
-    case {lists:member({consistent, true}, BucketProps),
-            lists:member({write_once, true}, BucketProps)} of
+    BucketPropsL = riak_kv_util:get_bucket_props(Bucket),
+    BucketPropsM = maps:from_list(BucketPropsL),
+    case {
+        maps:get(consistent, BucketPropsM, false),
+        maps:get(write_once, BucketPropsM, false)} of
         {true, _} ->
             consistent;
         {false, true} ->
             write_once;
         _ ->
-            Args = [From, RObj, PutOptions, Bucket, BucketProps],
+            Args = [From, RObj, PutOptions, Bucket, BucketPropsM, BucketPropsL],
             StartSideJob =
                 sidejob_supervisor:start_child(
                     riak_kv_put_fsm_sj, gen_fsm, start_link, [?MODULE, Args, []]
@@ -242,10 +249,16 @@ monitor_remote_coordinator(true = _UseAckP, MiddleMan, CoordNode, StateData) ->
 %% As test, but linked to the caller
 test_link(From, Object, PutOptions, StateProps) ->
     Bucket = riak_object:bucket(Object),
-    BucketProps = riak_kv_util:get_bucket_props(Bucket),
+    {bucket_props_list, BProps} =
+        lists:keyfind(bucket_props_list, 1, StateProps),
+    BucketPropsM = maps:from_list(BProps),
     gen_fsm:start_link(
         ?MODULE,
-        {test, [From, Object, PutOptions, Bucket, BucketProps], StateProps},
+        {
+            test,
+            [From, Object, PutOptions, Bucket, BucketPropsM, BProps],
+            StateProps
+        },
         []
     ).
 
@@ -257,7 +270,7 @@ test_link(From, Object, PutOptions, StateProps) ->
 %% ====================================================================
 
 %% @private
-init([From, RObj, Options0, Bucket, BucketProps]) ->
+init([From, RObj, Options0, Bucket, BucketPropsM, BucketPropsL]) ->
     Key = riak_object:key(RObj),
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     Options = proplists:unfold(Options0),
@@ -269,7 +282,8 @@ init([From, RObj, Options0, Bucket, BucketProps]) ->
             trace = Trace,
             options = Options,
             timing = riak_kv_fsm_timing:add_timing(prepare, []),
-            bucket_props = BucketProps
+            bucket_props_map = BucketPropsM,
+            bucket_props_list = BucketPropsL
         },
     gen_fsm:send_event(self(), timeout),
     case Trace of
@@ -314,12 +328,13 @@ prepare(
         State=#state{
             bkey = {Bucket, Key},
             options=Options,
-            bucket_props=BucketProps
+            bucket_props_map=BucketProps
         }
     ) ->
     StatTracked = get_option(stat_tracked, BucketProps, false),
-    N = get_n_val(Options, BucketProps),
-    ConditionCheck = get_option(condition_check, Options, false),
+    {SQ, AI, MC, CD, NV, ConditionCheck} =
+        get_options_for_prepare(Options),
+    N = get_n_val(NV, BucketProps),
     CheckR =
         case ConditionCheck of
             false ->
@@ -338,12 +353,13 @@ prepare(
                     ),
                 GetCheck
         end,
+    MailBoxCheck =
+        app_helper:get_env(riak_kv, mbox_check_enabled, true) andalso MC,
     case CheckR of
         ok ->
             get_preflist(
-                N,
-                State#state{tracked_bucket=StatTracked
-                }
+                N, SQ, AI, MailBoxCheck,
+                State#state{tracked_bucket=StatTracked, client_details = CD}
             );
         Error ->
             process_reply(Error, State)
@@ -353,7 +369,9 @@ prepare(
 validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                                       options = Options,
                                       robj = RObj0,
-                                      n=N, bucket_props = BucketProps,
+                                      n=N,
+                                      bucket_props_map = BucketProps,
+                                      bucket_props_list = LegacyProps,
                                       trace = Trace,
                                       preflist2 = Preflist2}) ->
     
@@ -413,9 +431,14 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
             InitVNodeOpts =
                 case {ReturnBody, Postcommit} of
                     {false, []} ->
-                        [{bucket_props, BucketProps}];
+                        [
+                            {bucket_props, LegacyProps}
+                        ];
                     _ ->
-                        [{returnbody, true}, {bucket_props, BucketProps}]
+                        [
+                            {returnbody, true},
+                            {bucket_props, LegacyProps}
+                        ]
                 end,
             RObj = apply_updates(RObj0, ULM),
             RR =
@@ -426,7 +449,7 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                             vclock:prune(
                                 Clock,
                                 riak_core_util:moment(),
-                                BucketProps
+                                LegacyProps
                             ),
                         case {length(MaybePrunedClock), length(Clock)} of
                             {PVL, UPVL} when PVL < UPVL ->
@@ -748,7 +771,44 @@ code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
 
 -type w_param() :: backend|one|quorum|all|default|non_neg_integer()|binary().
 
--spec get_options_for_validate(list(option()))->
+-spec get_options_for_prepare(list(option())) ->
+    {
+        boolean(),
+        boolean(),
+        boolean(),
+        detail(),
+        false|pos_integer(),
+        condition_check()
+    }.
+get_options_for_prepare(Options) ->
+    get_prepare_options(
+        lists:reverse(Options),
+        true,
+        false,
+        ?CAP_PUTFSM_SOFTLIMIT,
+        false,
+        false,
+        false
+    ).
+
+get_prepare_options([], SQ, AI, MC, CD, NV, CC) ->
+    {SQ, AI, MC, CD, NV, CC};
+get_prepare_options([{sloppy_quorum, SQ}|Opts], _SQ, AI, MC, CD, NV, CC) ->
+    get_prepare_options(Opts, SQ, AI, MC, CD, NV, CC);
+get_prepare_options([{asis, AI}|Opts], SQ, _AI, MC, CD, NV, CC) ->
+    get_prepare_options(Opts, SQ, AI, MC, CD, NV, CC);
+get_prepare_options([{mbox_check, MC}|Opts], SQ, AI, true, CD, NV, CC) ->
+    get_prepare_options(Opts, SQ, AI, MC, CD, NV, CC);
+get_prepare_options([{details, CD}|Opts], SQ, AI, MC, _CD, NV, CC) ->
+    get_prepare_options(Opts, SQ, AI, MC, CD, NV, CC);
+get_prepare_options([{n_val, NV}|Opts], SQ, AI, MC, CD, _NV, CC) ->
+    get_prepare_options(Opts, SQ, AI, MC, CD, NV, CC);
+get_prepare_options([{condition_check, CC}|Opts], SQ, AI, MC, CD, NV, _CC) ->
+    get_prepare_options(Opts, SQ, AI, MC, CD, NV, CC);
+get_prepare_options([_Opt|Opts], SQ, AI, MC, CD, NV, CC) ->
+    get_prepare_options(Opts, SQ, AI, MC, CD, NV, CC).
+
+-spec get_options_for_validate(list(option())) ->
     {
         pos_integer(),
         w_param(), w_param(), w_param(), w_param(), w_param(),
@@ -756,7 +816,11 @@ code_change(_OldVsn, StateName, State, _Extra) -> {ok, StateName, State}.
     }.
 get_options_for_validate(Options) ->
     get_validate_options(
-        Options,
+        lists:reverse(Options),
+            % make backwards compatible with proplists fetch
+            % if there are duplicate elements
+            % e.g. [{return_body, false}, {return_body, true}]
+            % take the first value
         ?DEFAULT_TIMEOUT,
         default, default, default, default, default,
         false, false, false, true
@@ -1022,14 +1086,20 @@ get_hooks(HookType, BucketProps) ->
             Hooks
     end.
 
-get_hooks(postcommit, BucketProps, #state{bkey=BKey}) ->
+get_hooks(postcommit, BucketProps, State) ->
     BaseHooks = get_hooks(postcommit, BucketProps),
-    CondHooks = riak_kv_hooks:get_conditional_postcommit(BKey, BucketProps),
+    CondHooks =
+        riak_kv_hooks:get_conditional_postcommit(
+            State#state.bkey,
+            State#state.bucket_props_list
+        ),
     BaseHooks ++ (CondHooks -- BaseHooks).
 
 get_option(Name, Options) ->
     get_option(Name, Options, undefined).
 
+get_option(Name, Options, Default) when is_map(Options) ->
+    maps:get(Name, Options, Default);
 get_option(Name, Options, Default) ->
     case lists:keyfind(Name, 1, Options) of
         {_, Val} ->
@@ -1045,10 +1115,11 @@ schedule_timeout(Timeout) ->
 
 client_reply(Reply, State = #state{from = {raw, ReqId, Pid},
                                    timing = Timing0,
-                                   options = Options}) ->
+                                   client_details = Details
+                                }) ->
     Timing = riak_kv_fsm_timing:add_timing(reply, Timing0),
     Reply2 =
-        case get_option(details, Options, false) of
+        case Details of
             false ->
                 Reply;
             [] ->
@@ -1100,9 +1171,9 @@ late_put_fsm_coordinator_ack(_Node) ->
 
 %% @private decide on the N Val for the put request, and error if
 %% there is a violation.
-get_n_val(Options, BucketProps) ->
+get_n_val(NV, BucketProps) ->
     Bucket_N = get_option(n_val, BucketProps),
-    case get_option(n_val, Options, false) of
+    case NV of
         false ->
             Bucket_N;
         N_val when is_integer(N_val), N_val > 0, N_val =< Bucket_N ->
@@ -1113,22 +1184,21 @@ get_n_val(Options, BucketProps) ->
     end.
 
 %% @private given no n-val violation, generate a preflist.
-get_preflist({error, _Reason}=Err, State) ->
+get_preflist({error, _Reason}=Err, _SQ, _AI, _MC, State) ->
     process_reply(Err, State);
-get_preflist(N, State) ->
+get_preflist(N, SQ, AI, MC, State) ->
     #state{bkey = BKey,
-           options = Options,
-           bucket_props=BucketProps,
+           bucket_props_list=BucketProps,
            bad_coordinators = BadCoordinators} = State,
 
     DocIdx = riak_core_util:chash_key(BKey, BucketProps),
 
     Preflist =
-        case get_option(sloppy_quorum, Options, true) of
+        case SQ of
             true ->
                 UpNodes = riak_core_node_watcher:nodes(riak_kv),
-                riak_core_apl:get_apl_ann(DocIdx, N,
-                                          UpNodes -- BadCoordinators);
+                riak_core_apl:get_apl_ann(
+                    DocIdx, N, UpNodes -- BadCoordinators);
             false ->
                 Preflist0 =
                     riak_core_apl:get_primary_apl(DocIdx, N, riak_kv),
@@ -1136,32 +1206,40 @@ get_preflist(N, State) ->
                       not lists:member(Node, BadCoordinators)]
         end,
 
-    coordinate_or_forward(Preflist, State#state{n=N}).
+    coordinate_or_forward(Preflist, AI, MC, State#state{n=N}).
 
 %% @private if there is a non-empty preflist, select a coordinator, as
 %% needed.
-coordinate_or_forward([], State=#state{trace=Trace}) ->
+coordinate_or_forward([], _AI, _MC, State=#state{trace=Trace}) ->
     %% Empty preflist
     ?DTRACE(Trace, ?C_PUT_FSM_PREPARE, [-1],
             ["prepare",<<"all nodes down">>]),
     process_reply({error, all_nodes_down}, State);
-coordinate_or_forward(Preflist, State) ->
-    #state{options = Options, n = N, trace=Trace} = State,
-    CoordinatorType = get_coordinator_type(Options),
-    MBoxCheck = get_soft_limit_option(Options),
+coordinate_or_forward(Preflist, Asis, MBoxCheck, State) ->
+    #state{n = N, trace=Trace} = State,
+    CoordinatorType = get_coordinator_type(Asis),
 
     case select_coordinator(Preflist, CoordinatorType, MBoxCheck) of
         {local, CoordPLEntry} ->
-            %% for DTRACE
-            CoordPlNode = case CoordPLEntry of
-                              undefined  -> undefined;
-                              {_Idx, Nd} -> atom2list(Nd)
-                          end,
-            StateData = State#state{n = N,
-                                    coord_pl_entry = CoordPLEntry,
-                                    preflist2 = Preflist},
-            ?DTRACE(Trace, ?C_PUT_FSM_PREPARE, [0],
-                    ["prepare", CoordPlNode]),
+            StateData =
+                State#state{
+                    n = N, coord_pl_entry = CoordPLEntry, preflist2 = Preflist
+                },
+            case Trace of
+                true ->
+                    CoordPlNode =
+                        case CoordPLEntry of
+                            undefined  ->
+                                undefined;
+                            {_Idx, Nd} ->
+                                atom2list(Nd)
+                        end,
+                    ?DTRACE(
+                        ?C_PUT_FSM_PREPARE, [0], ["prepare", CoordPlNode]
+                    );
+                _ ->
+                    ok
+            end,
             new_state_timeout(validate, StateData);
         {forward, ForwardNode} ->
             forward(ForwardNode, State)
@@ -1335,14 +1413,11 @@ add_errors_to_mbox_data(Preflist, Acc) ->
 
 %% @private decide if the coordinator has to be a local, causality
 %% advancing vnode, or no coordinator at all
--spec get_coordinator_type(options()) -> none | local.
-get_coordinator_type(Options) ->
-    case get_option(asis, Options, false) of
-        false ->
-            local;
-        true ->
-            none
-    end.
+-spec get_coordinator_type(boolean()) -> none | local.
+get_coordinator_type(false) ->
+    local;
+get_coordinator_type(true) ->
+    none.
 
 %% @private used by `coordinate_or_forward' above. Removes `Type' info
 %% from preflist entries and splits a preflist into local and remote.
@@ -1360,22 +1435,6 @@ partition_local_remote({{_Index, Node}=IN, _Type}, {L, R})
     {[IN | L], R};
 partition_local_remote({IN, _Type}, {L, R}) ->
     {L, [IN | R]}.
-
-%% @private get the soft-limit check option, and consult capabilities too.
-get_soft_limit_option(Options) ->
-    %% The logic here is to be as safe as possible. If caps system is
-    %% unavailble, then assume soft-limits are unsupported. If
-    %% capability _is_ available AND supported, then the value will be true
-    SoftLimitSupported = ?CAP_PUTFSM_SOFTLIMIT,
-    %% both the system (post forward) and the client (via options) can
-    %% turn off soft-limit checking. However, by default, we should
-    %% use them (if supported) - unless it is explicitly disabled by toggling the
-    %% mbox_check_enabled environment flag
-    SoftLimitedWanted =
-        app_helper:get_env(riak_kv, mbox_check_enabled, true) andalso
-        SoftLimitSupported andalso
-        get_option(mbox_check, Options, SoftLimitSupported),
-    SoftLimitedWanted.
 
 -spec conditional_check(
     {ok, riak_object:riak_object()}|{error, term()},
@@ -1458,12 +1517,6 @@ select_least_loaded_coordinator_test() ->
     ?assertEqual({local, {100, nodea}}, select_least_loaded_coordinator(MBoxData, [])),
     ?assertEqual({forward, nodea}, select_least_loaded_coordinator([], MBoxData)),
     ?assertEqual({local, {100, nodea}}, select_least_loaded_coordinator(MBoxData, MBoxData)).
-
-get_coordinator_type_test() ->
-    Opts0 = proplists:unfold([asis]),
-    ?assertEqual(none, get_coordinator_type(Opts0)),
-    Opts1 = proplists:unfold([]),
-    ?assertEqual(local, get_coordinator_type(Opts1)).
 
 get_bucket_props_test_() ->
     BucketProps = [{bprop1, bval1},
@@ -1560,12 +1613,9 @@ partition_local_remote_test() ->
                                                            ])).
 
 get_n_val_test() ->
-    Opts0 = [],
     BProps = [{n_val, 3}, {other, props}],
-    ?assertEqual(3, get_n_val(Opts0, BProps)),
-    Opts1 = [{n_val, 1}],
-    ?assertEqual(1, get_n_val(Opts1, BProps)),
-    Opts2 = [{n_val, 4}],
-    ?assertEqual({error, {n_val_violation, 4}}, get_n_val(Opts2, BProps)).
+    ?assertEqual(3, get_n_val(false, BProps)),
+    ?assertEqual(1, get_n_val(1, BProps)),
+    ?assertEqual({error, {n_val_violation, 4}}, get_n_val(4, BProps)).
 
 -endif.

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -26,7 +26,6 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
--include_lib("riak_kv_vnode.hrl").
 -include("riak_kv_types.hrl").
 -include("riak_kv_capability.hrl").
 
@@ -36,8 +35,7 @@
 
 -behaviour(gen_fsm).
 -define(DEFAULT_OPTS, [{returnbody, false}, {update_last_modified, true}]).
--export([start/3,start/6,start/7]).
--export([start_link/3,start_link/6,start_link/7]).
+-export([start/3]).
 -export([set_put_coordinator_failure_timeout/1,
          get_put_coordinator_failure_timeout/0]).
 -ifdef(TEST).
@@ -48,7 +46,7 @@
 -export([prepare/2, validate/2, precommit/2,
          waiting_local_vnode/2,
          waiting_remote_vnode/2,
-         postcommit/2, finish/2]).
+         postcommit/2, finish/2, abort/2]).
 -export([conditional_check/3]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -146,37 +144,34 @@
 %% Public API
 %% ===================================================================
 
-%% In place only for backwards compatibility
-start(ReqId,RObj,W,DW,Timeout,ResultPid) ->
-    start_link(ReqId,RObj,W,DW,Timeout,ResultPid,[]).
-
-%% In place only for backwards compatibility
-start(ReqId,RObj,W,DW,Timeout,ResultPid,Options) ->
-    start_link(ReqId,RObj,W,DW,Timeout,ResultPid,Options).
-
-start_link(ReqId,RObj,W,DW,Timeout,ResultPid) ->
-    start_link(ReqId,RObj,W,DW,Timeout,ResultPid,[]).
-
-start_link(ReqId,RObj,W,DW,Timeout,ResultPid,Options) ->
-    start({raw, ReqId, ResultPid}, RObj, [{w, W}, {dw, DW}, {timeout, Timeout} | Options]).
-
-start(From, Object, PutOptions) ->
-    Args = [From, Object, PutOptions],
-    case sidejob_supervisor:start_child(riak_kv_put_fsm_sj,
-                                        gen_fsm, start_link,
-                                        [?MODULE, Args, []]) of
-        {error, overload} ->
-            riak_kv_util:overload_reply(From),
-            {error, overload};
-        {ok, Pid} ->
-            {ok, Pid}
+-spec start(
+    {raw, non_neg_integer(), pid()},
+    riak_object:object(),
+    proplist:proplist()) ->
+        consistent|write_once|{ok, pid()}|{error, overload}.
+start(From, RObj, PutOptions) ->
+    Bucket = riak_object:bucket(RObj),
+    BucketProps = get_bucket_props(Bucket),
+    case {lists:member({consistent, true}, BucketProps),
+            lists:member({write_once, true}, BucketProps)} of
+        {true, _} ->
+            consistent;
+        {false, true} ->
+            write_once;
+        _ ->
+            Args = [From, RObj, PutOptions, Bucket, BucketProps],
+            StartSideJob =
+                sidejob_supervisor:start_child(
+                    riak_kv_put_fsm_sj, gen_fsm, start_link, [?MODULE, Args, []]
+                ), 
+            case StartSideJob of
+                {error, overload} ->
+                    riak_kv_util:overload_reply(From),
+                    {error, overload};
+                {ok, Pid} ->
+                    {ok, Pid}
+            end
     end.
-
-%% Included for backward compatibility, in case someone is, say, passing around
-%% a riak_client instace between nodes during a rolling upgrade. The old
-%% `start_link' function has been renamed `start' since it doesn't actually link
-%% to the caller.
-start_link(From, Object, PutOptions) -> start(From, Object, PutOptions).
 
 set_put_coordinator_failure_timeout(MS) when is_integer(MS), MS >= 0 ->
     application:set_env(riak_kv, put_coordinator_failure_timeout, MS);
@@ -248,7 +243,13 @@ monitor_remote_coordinator(true = _UseAckP, MiddleMan, CoordNode, StateData) ->
 %%
 %% As test, but linked to the caller
 test_link(From, Object, PutOptions, StateProps) ->
-    gen_fsm:start_link(?MODULE, {test, [From, Object, PutOptions], StateProps}, []).
+    Bucket = riak_object:bucket(Object),
+    BucketProps = get_bucket_props(Bucket),
+    gen_fsm:start_link(
+        ?MODULE,
+        {test, [From, Object, PutOptions, Bucket, BucketProps], StateProps},
+        []
+    ).
 
 -endif.
 
@@ -258,18 +259,23 @@ test_link(From, Object, PutOptions, StateProps) ->
 %% ====================================================================
 
 %% @private
-init([From, RObj, Options0]) ->
-    BKey = {Bucket, Key} = {riak_object:bucket(RObj), riak_object:key(RObj)},
+init([From, RObj, Options0, Bucket, BucketProps]) ->
+    Key = riak_object:key(RObj),
     CoordTimeout = get_put_coordinator_failure_timeout(),
     Trace = app_helper:get_env(riak_kv, fsm_trace_enabled),
     Options = proplists:unfold(Options0),
-    StateData = #state{from = From,
-                       robj = RObj,
-                       bkey = BKey,
-                       trace = Trace,
-                       options = Options,
-                       timing = riak_kv_fsm_timing:add_timing(prepare, []),
-                       coordinator_timeout=CoordTimeout},
+    StateData =
+        #state{
+            from = From,
+            robj = RObj,
+            bkey = {Bucket, Key},
+            trace = Trace,
+            options = Options,
+            timing = riak_kv_fsm_timing:add_timing(prepare, []),
+            coordinator_timeout=CoordTimeout,
+            bucket_props = BucketProps
+        },
+    gen_fsm:send_event(self(), timeout),
     case Trace of
         true ->
             riak_core_dtrace:put_tag([Bucket, $,, Key]),
@@ -285,7 +291,6 @@ init([From, RObj, Options0]) ->
         _ ->
             ok
     end,
-    gen_fsm:send_event(self(), timeout),
     {ok, prepare, StateData};
 init({test, Args, StateProps}) ->
     %% Call normal init
@@ -304,10 +309,18 @@ init({test, Args, StateProps}) ->
     %% state of the rest of the system
     {ok, validate, TestStateData}.
 
+abort(timeout, StateData) ->
+    {stop, normal, StateData}.
+
 %% @private
-prepare(timeout, State = #state{robj = RObj, options=Options}) ->
-    Bucket = riak_object:bucket(RObj),
-    BucketProps = get_bucket_props(Bucket),
+prepare(
+        timeout,
+        State=#state{
+            bkey = {Bucket, Key},
+            options=Options,
+            bucket_props=BucketProps
+        }
+    ) ->
     StatTracked = get_option(stat_tracked, BucketProps, false),
     N = get_n_val(Options, BucketProps),
     ConditionCheck = get_option(condition_check, Options, false),
@@ -316,7 +329,6 @@ prepare(timeout, State = #state{robj = RObj, options=Options}) ->
             false ->
                 ok;
             {NotMod, NoneMatch, GetOpts} ->
-                Key = riak_object:key(RObj),
                 {GetCheck, _PutOpts} =
                     riak_kv_put_fsm:conditional_check(
                         riak_client:get(
@@ -334,8 +346,7 @@ prepare(timeout, State = #state{robj = RObj, options=Options}) ->
         ok ->
             get_preflist(
                 N,
-                State#state{
-                    tracked_bucket=StatTracked, bucket_props=BucketProps
+                State#state{tracked_bucket=StatTracked
                 }
             );
         Error ->
@@ -437,25 +448,41 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                     _ ->
                         false
                 end,
-            PutCore = riak_kv_put_core:init(N, W, PW, NodeConfirms, DW,
-                                            AllowMult,
-                                            ReturnBody,
-                                            IdxType),
+            PutCore =
+                riak_kv_put_core:init(
+                    N,
+                    W,
+                    PW,
+                    NodeConfirms,
+                    DW,
+                    AllowMult,
+                    ReturnBody,
+                    IdxType
+                ),
             Options1 = lists:keydelete(sync_on_write, 1, Options),
             Options2 = [{sync_on_write, SyncOnWrite}|Options1],
             Options3 = [{rr, RR}|Options2],
-            VNodeOpts = handle_options(Options3, VNodeOpts0),
-            StateData = StateData0#state{n=N,
-                                         w=W,
-                                         pw=PW, node_confirms=NodeConfirms, dw=DW,
-                                         allowmult=AllowMult,
-                                         precommit = Precommit,
-                                         postcommit = Postcommit,
-                                         req_id = ReqId,
-                                         robj = RObj,
-                                         putcore = PutCore,
-                                         vnode_options = VNodeOpts,
-                                         timeout = Timeout},
+            VNodeOpts =
+                handle_options(
+                    Options3,
+                    [{bucket_props, BucketProps}|VNodeOpts0]
+                ),
+            StateData =
+                StateData0#state{
+                    n = N,
+                    w = W,
+                    pw = PW,
+                    node_confirms = NodeConfirms,
+                    dw=DW,
+                    allowmult = AllowMult,
+                    precommit = Precommit,
+                    postcommit = Postcommit,
+                    req_id = ReqId,
+                    robj = RObj,
+                    putcore = PutCore,
+                    vnode_options = VNodeOpts,
+                    timeout = Timeout
+                },
             ?DTRACE(Trace, ?C_PUT_FSM_VALIDATE, [N, W, PW, NodeConfirms, DW], []),
             case Precommit of
                 [] -> % Nothing to run, spare the timing code

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -361,7 +361,7 @@ get_index_n({Bucket, Key}) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     get_index_n({Bucket, Key}, BucketProps).
 
--spec get_index_n({binary(), binary()}, proplist:proplist()) -> index_n().
+-spec get_index_n({binary(), binary()}, proplists:proplist()) -> index_n().
 get_index_n({Bucket, Key}, BucketProps) ->
     N = proplists:get_value(n_val, BucketProps),
     ChashKey = riak_core_util:chash_key({Bucket, Key}, BucketProps),

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -35,6 +35,7 @@
         normalize_rw_value/2,
         make_request/2,
         get_index_n/1,
+        get_index_n/2,
         preflist_siblings/1,
         fix_incorrect_index_entries/1,
         fix_incorrect_index_entries/0,
@@ -358,6 +359,10 @@ reset_aae_key_filter() ->
 -spec get_index_n({binary(), binary()}) -> index_n().
 get_index_n({Bucket, Key}) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
+    get_index_n({Bucket, Key}, BucketProps).
+
+-spec get_index_n({binary(), binary()}, proplist:proplist()) -> index_n().
+get_index_n({Bucket, Key}, BucketProps) ->
     N = proplists:get_value(n_val, BucketProps),
     ChashKey = riak_core_util:chash_key({Bucket, Key}, BucketProps),
     {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
@@ -761,7 +766,7 @@ profile_riak(ProfileTime) ->
             case eprof:stop_profiling() of
                 profiling_stopped ->
                     eprof:analyze(
-                        total, [{filter, [{time, float(5 * ProfileTime)}]}]
+                        total, [{filter, [{time, float(8 * ProfileTime)}]}]
                     ),
                     stopped = eprof:stop(),
                     analyzed;

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -55,7 +55,8 @@
         shuffle_list/1,
         kv_ready/0,
         ngr_initial_timeout/0,
-        sys_monitor_count/0
+        sys_monitor_count/0,
+        get_bucket_props/1
     ]).
 -export([report_hashtree_tokens/0, reset_hashtree_tokens/2]).
 -export([reset_aae_key_filter/0]).
@@ -285,6 +286,19 @@ kv_ready() ->
 -spec ngr_initial_timeout() -> pos_integer().
 ngr_initial_timeout() ->
     application:get_env(riak_kv, ngr_initial_timeout, 60000).
+
+-spec get_bucket_props(riak_object:bucket()) -> list().
+get_bucket_props(Bucket) ->
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    %% typed buckets never fall back to defaults
+    case is_tuple(Bucket) of
+        false ->
+            {ok, DefaultProps} =
+                application:get_env(riak_core, default_bucket_props),
+            riak_core_bucket_props:merge(BucketProps, DefaultProps);
+        true ->
+            BucketProps
+    end.
 
 %% ===================================================================
 %% Hashtree token management functions

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -158,11 +158,19 @@ make_request(Request, Index) ->
                                         {fsm, undefined, self()},
                                         Index).
 
-get_bucket_option(Type, BucketProps) ->
-    case lists:keyfind(Type, 1, BucketProps) of
-        {Type, Val} -> Val;
+get_bucket_option(Name, BucketProps) when is_map(BucketProps) ->
+    case maps:get(Name, BucketProps, undefined) of
+        undefined ->
+            get_default_bucket_option(Name);
+        Val ->
+            Val
+    end;
+get_bucket_option(Name, BucketProps) ->
+    case lists:keyfind(Name, 1, BucketProps) of
+        {Name, Val} ->
+            Val;
         _ ->
-            get_default_bucket_option(Type)
+            get_default_bucket_option(Name)
     end.
 
 get_default_bucket_option(Type) ->

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -63,6 +63,7 @@
 
 -export([
     profile_riak/1,
+    profile_riak/2,
     top_n_binary_total_memory/1,
     summarise_binary_memory_by_initial_call/1,
     top_n_process_total_memory/1,
@@ -781,6 +782,9 @@ summarise_process_memory_by_initial_call(TopN) when is_list(TopN) ->
 %% best to restrict ProfileTime to 100ms.  May fail on systems under heavy load
 -spec profile_riak(pos_integer()) -> analyzed|failed.
 profile_riak(ProfileTime) ->
+    profile_riak(ProfileTime, 8).
+
+profile_riak(ProfileTime, ProfileRatio) ->
     eprof:start(),
     case eprof:start_profiling(erlang:processes()) of
         profiling ->
@@ -788,7 +792,12 @@ profile_riak(ProfileTime) ->
             case eprof:stop_profiling() of
                 profiling_stopped ->
                     eprof:analyze(
-                        total, [{filter, [{time, float(8 * ProfileTime)}]}]
+                        total, [
+                            {
+                                filter,
+                                [{time, float(ProfileRatio * ProfileTime)}]
+                            }
+                        ]
                     ),
                     stopped = eprof:stop(),
                     analyzed;

--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -359,7 +359,7 @@ reset_aae_key_filter() ->
 get_index_n({Bucket, Key}) ->
     BucketProps = riak_core_bucket:get_bucket(Bucket),
     N = proplists:get_value(n_val, BucketProps),
-    ChashKey = riak_core_util:chash_key({Bucket, Key}),
+    ChashKey = riak_core_util:chash_key({Bucket, Key}, BucketProps),
     {ok, CHBin} = riak_core_ring_manager:get_chash_bin(),
     Index = chashbin:responsible_index(ChashKey, CHBin),
     {Index, N}.
@@ -761,7 +761,7 @@ profile_riak(ProfileTime) ->
             case eprof:stop_profiling() of
                 profiling_stopped ->
                     eprof:analyze(
-                        total, [{filter, [{time, float(10 * ProfileTime)}]}]
+                        total, [{filter, [{time, float(5 * ProfileTime)}]}]
                     ),
                     stopped = eprof:stop(),
                     analyzed;

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -4265,7 +4265,7 @@ encode_and_put(
     Obj, Mod, Bucket, Key, IndexSpecs, ModState, MaxCheckFlag, Coord, Sync
 ) ->
     DoMaxCheck = MaxCheckFlag == do_max_check,
-    case sibling_check(MaxCheckFlag == do_max_check, Coord, Obj) of
+    case sibling_check(DoMaxCheck, Coord, Obj) of
         {too_many_siblings, NumSiblings} ->
             ?LOG_ERROR(
                 "Put failure: too many siblings for object ~p/~p (~p)",

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -4984,4 +4984,81 @@ rollover_test_() ->
     }.
 
 
+proplist_fetcher(DProps) ->
+    {
+        proplists:get_value(dvv_enabled, DProps, true),
+        proplists:get_value(write_once, DProps, false),
+        proplists:get_value(allow_mult, DProps, undefined)
+    }.
+
+map_fetcher(DProps) ->
+    M = maps:from_list(DProps),
+    {
+        maps:get(dvv_enabled, M, true),
+        maps:get(write_once, M, false),
+        maps:get(allow_mult, M, undefined)
+    }.
+
+speed_test() ->
+    %% What is the fastest way of getting three bucket properties?
+    %% On my machine - Speed compare 9239 10455 26193
+    DefaultProps =
+        [
+            {node_confirms,0},
+            {dvv_enabled,false},
+            {allow_mult,false},
+            {linkfun,{modfun,riak_kv_wm_link_walker,mapreduce_linkfun}},
+            {old_vclock,86400},
+            {young_vclock,20},
+            {big_vclock,50},
+            {small_vclock,50},
+            {pr,0},
+            {r,quorum},
+            {w,quorum},
+            {pw,0},
+            {dw,quorum},
+            {rw,quorum},
+            {sync_on_write,backend},
+            {basic_quorum,false},
+            {notfound_ok,true},
+            {n_val,3},
+            {last_write_wins,false},
+            {precommit,[]},
+            {postcommit,[]},
+            {chash_keyfun,{riak_core_util,chash_std_keyfun}}
+        ],
+    
+        {TC0, R0} =
+            timer:tc(
+                fun() ->
+                    lists:map(
+                        fun(_I) -> get_put_properties(DefaultProps) end,
+                        lists:seq(1, 100000)
+                    )
+                end
+            ),
+        {TC1, R1} =
+            timer:tc(
+                fun() ->
+                    lists:map(
+                        fun(_I) -> proplist_fetcher(DefaultProps) end,
+                        lists:seq(1, 100000)
+                    )
+                end
+            ),
+        {TC2, R2} =
+            timer:tc(
+                fun() ->
+                    lists:map(
+                        fun(_I) -> map_fetcher(DefaultProps) end,
+                        lists:seq(1, 100000)
+                    )
+                end
+            ),
+        ?assertMatch(R0, R1),
+        ?assertMatch(R0, R2),
+        io:format(user, "Speed compare ~w ~w ~w~n", [TC0, TC1, TC2])
+    .
+
+
 -endif.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -3115,19 +3115,18 @@ prepare_put_existing_object(#state{idx =Idx} = State,
     end.
 
 get_put_properties(BProps) ->
-    {
-        keyfind(dvv_enabled, BProps, true),
-        keyfind(write_once, BProps, false),
-        keyfind(allow_mult, BProps, undefined)
-    }.
+    get_put_properties(BProps, true, false, undefined).
 
-keyfind(Key, BProps, Default) when is_atom(Key) ->
-    case lists:keyfind(Key, 1, BProps) of
-        {Key, Value} ->
-            Value;
-        _ ->
-            Default
-    end.
+get_put_properties([], DVV, WriteOnce, AM) ->
+    {DVV, WriteOnce, AM};
+get_put_properties([{dvv_enabled, DVV}|Props], _DVV, WriteOnce, AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM);
+get_put_properties([{write_once, WriteOnce}|Props], DVV, _WriteOnce, AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM);
+get_put_properties([{allow_mult, AM}|Props], DVV, WriteOnce, _AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM);
+get_put_properties([_Prop|Props], DVV, WriteOnce, AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM).
 
 determine_put_result({error, E}, _, Idx, PutArgs, State, _IndexSpecs, _IndexBackend) ->
     {{fail, Idx, E}, PutArgs, State};
@@ -4984,26 +4983,6 @@ rollover_test_() ->
              ]}
     }.
 
-roll_put_properties(BProps) ->
-    roll_put_properties(BProps, true, false, undefined).
-
-roll_put_properties([], DVV, WriteOnce, AM) ->
-    {DVV, WriteOnce, AM};
-roll_put_properties([{dvv_enabled, DVV}|Props], _DVV, WriteOnce, AM) ->
-    roll_put_properties(Props, DVV, WriteOnce, AM);
-roll_put_properties([{write_once, WriteOnce}|Props], DVV, _WriteOnce, AM) ->
-    roll_put_properties(Props, DVV, WriteOnce, AM);
-roll_put_properties([{allow_mult, AM}|Props], DVV, WriteOnce, _AM) ->
-    roll_put_properties(Props, DVV, WriteOnce, AM);
-roll_put_properties([_Prop|Props], DVV, WriteOnce, AM) ->
-    roll_put_properties(Props, DVV, WriteOnce, AM).
-
-keyfind_fetcher(DProps) ->
-    {
-        keyfind(dvv_enabled, DProps, true),
-        keyfind(write_once, DProps, false),
-        keyfind(allow_mult, DProps, undefined)
-    }.
 
 proplist_fetcher(DProps) ->
     {
@@ -5049,50 +5028,37 @@ speed_test() ->
             {chash_keyfun,{riak_core_util,chash_std_keyfun}}
         ],
     
-    {TC0, R0} =
-        timer:tc(
-            fun() ->
-                lists:map(
-                    fun(_I) -> roll_put_properties(DefaultProps) end,
-                    lists:seq(1, 100000)
-                )
-            end
-        ),
-    {TC1, R1} =
-        timer:tc(
-            fun() ->
-                lists:map(
-                    fun(_I) -> proplist_fetcher(DefaultProps) end,
-                    lists:seq(1, 100000)
-                )
-            end
-        ),
-    {TC2, R2} =
-        timer:tc(
-            fun() ->
-                lists:map(
-                    fun(_I) -> map_fetcher(DefaultProps) end,
-                    lists:seq(1, 100000)
-                )
-            end
-        ),
-    {TC3, R3} =
-        timer:tc(
-            fun() ->
-                lists:map(
-                    fun(_I) -> keyfind_fetcher(DefaultProps) end,
-                    lists:seq(1, 100000)
-                )
-            end
-        ),
-    ?assertMatch(R0, R1),
-    ?assertMatch(R0, R2),
-    ?assertMatch(R0, R3),
-    io:format(
-        user,
-        "Speed compare ~w ~w ~w ~w~n",
-        [TC0, TC1, TC2, TC3]
-    ).
+        {TC0, R0} =
+            timer:tc(
+                fun() ->
+                    lists:map(
+                        fun(_I) -> get_put_properties(DefaultProps) end,
+                        lists:seq(1, 100000)
+                    )
+                end
+            ),
+        {TC1, R1} =
+            timer:tc(
+                fun() ->
+                    lists:map(
+                        fun(_I) -> proplist_fetcher(DefaultProps) end,
+                        lists:seq(1, 100000)
+                    )
+                end
+            ),
+        {TC2, R2} =
+            timer:tc(
+                fun() ->
+                    lists:map(
+                        fun(_I) -> map_fetcher(DefaultProps) end,
+                        lists:seq(1, 100000)
+                    )
+                end
+            ),
+        ?assertMatch(R0, R1),
+        ?assertMatch(R0, R2),
+        io:format(user, "Speed compare ~w ~w ~w~n", [TC0, TC1, TC2])
+    .
 
 
 -endif.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -1099,7 +1099,15 @@ handle_command({hashtree_pid, Node}, _, State=#state{hashtrees=HT}) ->
 handle_command({rehash, Bucket, Key}, _, State=#state{mod=Mod, modstate=ModState}) ->
     case do_get_binary(Bucket, Key, Mod, ModState) of
         {ok, Bin, _UpdModState} ->
-            aae_update(Bucket, Key, use_binary, unknown_no_old_object, Bin, State);
+            aae_update(
+                Bucket,
+                Key,
+                use_binary,
+                unknown_no_old_object,
+                Bin,
+                undefined,
+                State
+            );
         _ ->
             %% Make sure hashtree isn't tracking deleted data
             aae_delete(Bucket, Key, confirmed_no_old_object, State)
@@ -1133,9 +1141,15 @@ handle_command({refresh_index_data, BKey, OldIdxData}, Sender,
             end,
             case Exists of
                 true ->
-                    aae_update(Bucket, Key, 
-                                RObj, unknown_no_old_object, use_object, 
-                                State);
+                    aae_update(
+                        Bucket,
+                        Key, 
+                        RObj,
+                        unknown_no_old_object,
+                        use_object,
+                        undefined, 
+                        State
+                    );
                 false ->
                     aae_delete(Bucket, Key, confirmed_no_old_object, State)
             end,
@@ -1636,7 +1650,15 @@ handle_request(kv_w1c_put_request, Req, _Sender, State=#state{async_put=false, u
     StartTS = os:timestamp(),
     case Mod:put(Bucket, Key, [], EncodedVal, ModState) of
         {ok, UpModState} ->
-            aae_update(Bucket, Key, use_binary, assumed_no_old_object, EncodedVal, State),
+            aae_update(
+                Bucket,
+                Key,
+                use_binary,
+                assumed_no_old_object,
+                EncodedVal,
+                undefined,
+                State
+            ),
                 % Write once path - and so should be a new object.  If not this
                 % is an application fault
             maybe_update_binary(UpdateHook, Bucket, Key, EncodedVal, put, Idx),
@@ -2617,7 +2639,15 @@ terminate(_Reason, #state{idx=Idx,
 
 handle_info({{w1c_async_put, From, Type, Bucket, Key, EncodedVal, StartTS} = _Context, Reply},
             State=#state{idx=Idx, update_hook=UpdateHook}) ->
-    aae_update(Bucket, Key, use_binary, assumed_no_old_object, EncodedVal, State),
+    aae_update(
+        Bucket,
+        Key,
+        use_binary,
+        assumed_no_old_object,
+        EncodedVal,
+        undefined,
+        State
+    ),
         % Write once path - and so should be a new object.  If not this
         % is an application fault
     maybe_update_binary(UpdateHook, Bucket, Key, EncodedVal, put, Idx),
@@ -3069,19 +3099,24 @@ get_index_specs(_IndexedBackend=true, CacheData, RequiresGet, NewObj, OldObj) ->
 get_index_specs(_IndexedBackend=false, _CacheData, _RequiresGet, _NewObj, _OldObj) ->
     [].
 
-prepare_put_new_object(#state{idx =Idx} = State,
-               #putargs{robj = RObj,
-                        coord=Coord,
-                        starttime=StartTime,
-                        crdt_op=CRDTOp} = PutArgs,
-                       IndexBackend) ->
-    IndexSpecs = case IndexBackend of
-                     true ->
-                         riak_object:index_specs(RObj);
-                     false ->
-                         []
-                 end,
-    {EpochId, State2, RObj2} = maybe_update_vclock(Coord, RObj, State, StartTime),
+prepare_put_new_object(
+        #state{idx =Idx} = State,
+        #putargs{
+            robj = RObj,
+            coord=Coord,
+            starttime=StartTime,
+            bprops=BProps,
+            crdt_op=CRDTOp} = PutArgs,
+        IndexBackend) ->
+    IndexSpecs =
+        case IndexBackend of
+            true ->
+                riak_object:index_specs(RObj);
+            false ->
+                []
+        end,
+    DVV = proplists:get_value(dvv_enabled, BProps, true),
+    {EpochId, State2, RObj2} = maybe_update_vclock(Coord, RObj, State, StartTime, DVV),
     RObj3 = maybe_do_crdt_update(Coord, CRDTOp, EpochId, RObj2),
     determine_put_result(RObj3, confirmed_no_old_object, Idx, PutArgs, State2, IndexSpecs, IndexBackend).
 
@@ -3115,17 +3150,25 @@ determine_requires_get(CacheClock, RObj, IsSearchable) ->
 
 %% @Doc in the case that this a co-ordinating put, prepare the object.
 %% NOTE: this is called _only_ when the local object is `notfound'
--spec maybe_update_vclock(Coord::boolean(),
-                          IncomingObject:: riak_object:riak_object(),
-                          #state{},
-                          StartTime::term()) ->
-                                 {EpochId :: binary(),
-                                  #state{},
-                                  Object::riak_object:riak_object()}.
-maybe_update_vclock(Coord=true, RObj, State, StartTime) ->
+-spec maybe_update_vclock(
+    Coord::boolean(),
+    IncomingObject:: riak_object:riak_object(),
+    #state{},
+    StartTime::term(),
+    DVV :: boolean()) ->
+        {
+            EpochId :: binary(),
+            #state{},
+            Object::riak_object:riak_object()
+        }.
+maybe_update_vclock(Coord=true, RObj, State, StartTime, DVV) ->
     {_IsNewEpoch, EpochId, State2} = maybe_new_key_epoch(Coord, State, undefined, RObj),
-    {EpochId, State2, riak_object:increment_vclock(RObj, EpochId, StartTime)};
-maybe_update_vclock(_Coord=false, RObj, State, _StartTime) ->
+    {
+        EpochId,
+        State2,
+        riak_object:increment_vclock(RObj, EpochId, StartTime, DVV)
+    };
+maybe_update_vclock(_Coord=false, RObj, State, _StartTime, _DVV) ->
     %% @see maybe_new_actor_epoch/2 for details as to why the vclock
     %% may be updated on a non-coordinating put
     maybe_new_actor_epoch(RObj, State).
@@ -3160,14 +3203,18 @@ perform_put({false, {_Obj, _OldObj}},
     {{dw, Idx, ReqId}, State};
 perform_put({true, {_Obj, _OldObj}=Objects},
             State,
-            #putargs{returnbody=RB,
-                     bkey=BKey,
-                     reqid=ReqID,
-                     coord=Coord,
-                     index_specs=IndexSpecs,
-                     readrepair=ReadRepair,
-                     sync_on_write=SyncOnWrite,
-                     reason=HookReason}) ->
+            #putargs{
+                returnbody=RB,
+                bkey=BKey,
+                reqid=ReqID,
+                coord=Coord,
+                index_specs=IndexSpecs,
+                readrepair=ReadRepair,
+                sync_on_write=SyncOnWrite,
+                reason=HookReason,
+                bprops = BucketProps
+            }
+        ) ->
     case ReadRepair of
       true ->
         MaxCheckFlag = no_max_check;
@@ -3191,13 +3238,13 @@ perform_put({true, {_Obj, _OldObj}=Objects},
     {Reply, State2} =
         actual_put(
             BKey, Objects, IndexSpecs, RB, ReqID, MaxCheckFlag,
-            {Coord, Sync}, HookReason, State),
+            {Coord, Sync}, HookReason, BucketProps, State),
     {Reply, State2}.
 
 actual_put(BKey, {Obj, OldObj}, IndexSpecs, RB, ReqID, State) ->
     actual_put(
         BKey, {Obj, OldObj}, IndexSpecs, RB, ReqID, do_max_check,
-        {false, false}, put, State).
+        {false, false}, put, undefined, State).
 
 actual_put(BKey={Bucket, Key},
             {Obj, OldObj},
@@ -3206,6 +3253,7 @@ actual_put(BKey={Bucket, Key},
             MaxCheckFlag,
             {Coord, Sync},
             HookReason,
+            BucketProps,
             State=#state{idx=Idx,
                             mod=Mod,
                             modstate=ModState,
@@ -3213,7 +3261,9 @@ actual_put(BKey={Bucket, Key},
     case encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState,
                        MaxCheckFlag, Sync) of
         {{ok, UpdModState}, EncodedVal} ->
-            aae_update(Bucket, Key, Obj, OldObj, EncodedVal, State),
+            aae_update(
+                Bucket, Key, Obj, OldObj, EncodedVal, BucketProps, State
+            ),
             nextgenrepl(Bucket, Key, Obj, size(EncodedVal),
                         Coord,
                         State#state.enable_nextgenreplsrc,
@@ -3330,11 +3380,11 @@ select_newest_content(Mult) ->
 %% @private
 put_merge(false, true, _CurObj, UpdObj, _VId, _StartTime, _WO, _DVV) -> % coord=false, LWW=true
     {newobj, UpdObj};
-put_merge(false, false, CurObj, UpdObj, {NewEpoch, VId}, _StartTime, _WO, _DVV) -> % coord=false, LWW=false
+put_merge(false, false, CurObj, UpdObj, {NewEpoch, VId}, _StartTime, WO, DVV) -> % coord=false, LWW=false
     %% a downstream merge, or replication of a coordinated PUT
     %% Merge the value received with local replica value
     %% and store the value IFF it is different to what we already have
-    ResObj = riak_object:syntactic_merge(CurObj, UpdObj),
+    ResObj = riak_object:syntactic_merge(CurObj, UpdObj, {WO, DVV}),
     case NewEpoch of
         true ->
             {newobj, riak_object:new_actor_epoch(ResObj, VId)};
@@ -3835,20 +3885,23 @@ nextgenrepl(_B, _K, _Obj, _Size, _Coord, _Enabled, _Limit) ->
     ok.
 
 
--spec aae_update(binary(), binary(),
-                    riak_object:riak_object()|none|undefined|use_binary,
-                    old_object(),
-                    binary()|use_object, 
-                        % cannot be use_object if object is use_binary
-                    state()) -> ok.
+-spec aae_update(
+    binary(), binary(),
+    riak_object:riak_object()|none|undefined|use_binary,
+    old_object(),
+    binary()|use_object, 
+        % cannot be use_object if object is use_binary
+    proplist:proplist() | undefined,
+    state())
+        -> ok.
 %% @doc
 %% Update both the AAE controller (tictac aae) and old school hashtree aae
 %% if either or both are enabled.
-aae_update(_Bucket, _Key, _UpdObj, _PrevObj, _UpdObjBin,
+aae_update(_Bucket, _Key, _UpdObj, _PrevObj, _UpdObjBin, _BucketProps,
             #state{hashtrees = HTs, tictac_aae = TAAE} = _State) 
             when HTs == undefined, TAAE == false ->
     ok;
-aae_update(Bucket, Key, UpdObj, PrevObj, UpdObjBin,
+aae_update(Bucket, Key, UpdObj, PrevObj, UpdObjBin, BucketProps,
             #state{hashtrees = HTs, tictac_aae = TAAE} = State) ->
     Async = async_aae(State#state.aae_tokenbucket),
     case HTs of 
@@ -3880,7 +3933,13 @@ aae_update(Bucket, Key, UpdObj, PrevObj, UpdObjBin,
                         get_clock(UpdObj)
                 end,
             PrevClock = get_clock(PrevObj),
-            IndexN = riak_kv_util:get_index_n({Bucket, Key}),
+            IndexN =
+                case BucketProps of
+                    undefined ->
+                        riak_kv_util:get_index_n({Bucket, Key});
+                    BucketProps when is_list(BucketProps) ->
+                        riak_kv_util:get_index_n({Bucket, Key}, BucketProps)
+                end,
             ObjBin = 
                 case UpdObjBin of 
                     use_object ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -3315,8 +3315,9 @@ actual_put(BKey={Bucket, Key},
                             mod=Mod,
                             modstate=ModState,
                             update_hook=UpdateHook}) ->
-    case encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState,
-                       MaxCheckFlag, Sync) of
+    case encode_and_put(
+        Obj, Mod, Bucket, Key, IndexSpecs, ModState, MaxCheckFlag, Coord, Sync
+    ) of
         {{ok, UpdModState}, EncodedVal} ->
             aae_update(
                 Bucket, Key, Obj, OldObj, EncodedVal, BucketProps, State
@@ -4248,69 +4249,128 @@ return_encoded_binary_object(Method, EncodedObject) ->
     term_to_binary({ Method, EncodedObject }).
 
 -spec encode_and_put(
-        Obj::riak_object:riak_object(), Mod::term(), Bucket::riak_object:bucket(),
-        Key::riak_object:key(), IndexSpecs::list(), ModState::term(),
-        MaxCheckFlag::no_max_check | do_max_check, Sync::boolean()) ->
+        Obj::riak_object:riak_object(),
+        Mod::term(),
+        Bucket::riak_object:bucket(),
+        Key::riak_object:key(),
+        IndexSpecs::list(),
+        ModState::term(),
+        MaxCheckFlag::no_max_check | do_max_check,
+        Coord::boolean(),
+        Sync::boolean()) ->
            {{ok, UpdModState::term()}, EncodedObj::binary()} |
            {{error, Reason::term(), UpdModState::term()}, EncodedObj::binary()}.
 
-encode_and_put(Obj, Mod, Bucket, Key, IndexSpecs, ModState, MaxCheckFlag, Sync) ->
+encode_and_put(
+    Obj, Mod, Bucket, Key, IndexSpecs, ModState, MaxCheckFlag, Coord, Sync
+) ->
     DoMaxCheck = MaxCheckFlag == do_max_check,
-    NumSiblings = riak_object:value_count(Obj),
-    case DoMaxCheck andalso
-         NumSiblings > app_helper:get_env(riak_kv, max_siblings) of
-        true ->
-            ?LOG_ERROR("Put failure: too many siblings for object ~p/~p (~p)",
-                        [Bucket, Key, NumSiblings]),
-            {{error, {too_many_siblings, NumSiblings}, ModState},
-             undefined};
-        false ->
-            case NumSiblings > app_helper:get_env(riak_kv, warn_siblings) of
-                true ->
-                    ?LOG_WARNING("Too many siblings for object ~p/~p (~p)",
-                                  [Bucket, Key, NumSiblings]);
-                false ->
+    case sibling_check(MaxCheckFlag == do_max_check, Coord, Obj) of
+        {too_many_siblings, NumSiblings} ->
+            ?LOG_ERROR(
+                "Put failure: too many siblings for object ~p/~p (~p)",
+                [Bucket, Key, NumSiblings]
+            ),
+            {{error, {too_many_siblings, NumSiblings}, ModState}, undefined};
+        NotTooMany ->
+            case NotTooMany of
+                {sibling_warning, NumSiblings} ->
+                    ?LOG_WARNING(
+                        "Too many siblings for object ~p/~p (~p)",
+                        [Bucket, Key, NumSiblings]
+                    );
+                _ ->
                     ok
             end,
-            encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs,
-                                        ModState, MaxCheckFlag, Sync)
-    end.
-
-encode_and_put_no_sib_check(Obj, Mod, Bucket, Key, IndexSpecs, ModState,
-                            MaxCheckFlag, Sync) ->
-    DoMaxCheck = MaxCheckFlag == do_max_check,
-    case uses_r_object(Mod, ModState, Bucket) of
-        true ->
-            %% Non binary returning backends will have to handle size warnings
-            %% and errors themselves.
-            Mod:put_object(Bucket, Key, IndexSpecs, Obj, ModState);
-        false ->
-            ObjFmt = object_format(Mod, ModState),
-            EncodedVal = riak_object:to_binary(ObjFmt, Obj),
-            BinSize = size(EncodedVal),
-            %% Report or fail on large objects
-            case DoMaxCheck andalso
-                 BinSize > app_helper:get_env(riak_kv, max_object_size) of
+            case uses_r_object(Mod, ModState, Bucket) of
                 true ->
-                    ?LOG_ERROR("Put failure: object too large to write ~p/~p ~p bytes",
-                                [Bucket, Key, BinSize]),
-                    {{error, {too_large, BinSize}, ModState},
-                     EncodedVal};
+                    %% Non binary returning backends will have to handle size warnings
+                    %% and errors themselves.
+                    Mod:put_object(Bucket, Key, IndexSpecs, Obj, ModState);
                 false ->
-                    WarnSize = app_helper:get_env(riak_kv, warn_object_size),
-                    case BinSize > WarnSize of
-                       true ->
-                            ?LOG_WARNING("Writing very large object " ++
-                                          "(~p bytes) to ~p/~p",
-                                          [BinSize, Bucket, Key]);
-                        false ->
-                            ok
-                    end,
-                    PutFun = select_put_fun(Mod, ModState, Sync),
-                    PutRet = PutFun(Bucket, Key, IndexSpecs, EncodedVal, ModState),
-                    {PutRet, EncodedVal}
+                    ObjFmt = object_format(Mod, ModState),
+                    EncodedVal = riak_object:to_binary(ObjFmt, Obj),
+                    case size_check(DoMaxCheck, Coord, EncodedVal) of
+                        {too_large, BinSize} ->
+                             ?LOG_ERROR(
+                                "Put failure: "
+                                "object too large to write ~p/~p ~p bytes",
+                                [Bucket, Key, BinSize]
+                            ),
+                            {
+                                {error, {too_large, BinSize}, ModState},
+                                EncodedVal
+                            };
+                        NoTooBig ->
+                            case NoTooBig of
+                                {size_warning, BinSize} ->
+                                    ?LOG_WARNING(
+                                        "Writing very large object "
+                                        "(~p bytes) to ~p/~p",
+                                        [BinSize, Bucket, Key]
+                                    );
+                                _ ->
+                                    ok
+                            end,
+                            PutFun = select_put_fun(Mod, ModState, Sync),
+                            PutRet =
+                                PutFun(
+                                    Bucket,
+                                    Key,
+                                    IndexSpecs,
+                                    EncodedVal,
+                                    ModState
+                                ),
+                            {PutRet, EncodedVal}
+                    end
             end
     end.
+
+size_check(_, false, _EncodedVal) ->
+    ok;
+size_check(true, true, EncodedVal) ->
+    BinSize = size(EncodedVal),
+    MaxSize = app_helper:get_env(riak_kv, max_object_size),
+    case BinSize >  MaxSize of
+        true ->
+            {too_large, BinSize};
+        false ->
+            size_check(false, true, BinSize)
+    end;
+size_check(false, true, BinSize) when is_integer(BinSize) ->
+    WarnSize = app_helper:get_env(riak_kv, warn_object_size),
+    case BinSize > WarnSize of
+        true ->
+            {size_warning, BinSize};
+        false ->
+            ok
+    end;
+size_check(false, true, EncodedVal) ->
+    BinSize = size(EncodedVal),
+    size_check(false, true, BinSize).
+
+sibling_check(_, false, _Obj) ->
+    ok;
+sibling_check(true, true, Obj) ->
+    NumSiblings = riak_object:value_count(Obj),
+    MaxSiblings = app_helper:get_env(riak_kv, max_siblings),
+    case NumSiblings > MaxSiblings of
+        true ->
+            {too_many_siblings, NumSiblings};
+        false ->
+            sibling_check(false, true, NumSiblings)
+    end;
+sibling_check(false, true, NumSiblings) when is_integer(NumSiblings) ->
+    WarnSiblings = app_helper:get_env(riak_kv, warn_siblings),
+    case NumSiblings > WarnSiblings of
+        true ->
+            {sibling_warning, NumSiblings};
+        false ->
+            ok
+    end;
+sibling_check(false, true, Obj) ->
+    NumSiblings = riak_object:value_count(Obj),
+    sibling_check(false, true, NumSiblings).
 
 -spec select_put_fun(Mod::term(), ModState::term(), Sync::boolean()) -> fun().
 select_put_fun(Mod, ModState, Sync) ->

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -100,7 +100,7 @@
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("riak_core/include/riak_core_bg_manager.hrl").
--export([put_merge/6]). %% For fsm_eqc_vnode
+-export([put_merge/8]). %% For fsm_eqc_vnode
 -endif.
 
 -record(mrjob, {cachekey :: term(),
@@ -2835,19 +2835,21 @@ do_put(Sender, Request, State) ->
 %% @private
 %% upon receipt of a client-initiated put
 do_put(Sender, {Bucket, _Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
-    BProps =  case proplists:get_value(bucket_props, Options) of
-                  undefined ->
-                      riak_core_bucket:get_bucket(Bucket);
-                  Props ->
-                      Props
-              end,
+    BProps =
+        case proplists:get_value(bucket_props, Options) of
+            undefined ->
+                riak_core_bucket:get_bucket(Bucket);
+            Props ->
+                Props
+        end,
     ReadRepair = proplists:get_value(rr, Options, false),
-    PruneTime = case ReadRepair of
-                    true ->
-                        undefined;
-                    false ->
-                        StartTime
-                end,
+    PruneTime =
+        case ReadRepair of
+            true ->
+                undefined;
+            false ->
+                StartTime
+        end,
     Coord = proplists:get_value(coord, Options, false),
     SyncOnWrite = proplists:get_value(sync_on_write, Options, undefined),
     CRDTOp = proplists:get_value(counter_op, Options, proplists:get_value(crdt_op, Options, undefined)),
@@ -3014,7 +3016,9 @@ prepare_put_existing_object(#state{idx =Idx} = State,
                              crdt_op = CRDTOp}=PutArgs,
                             OldObj, IndexBackend, CacheData, RequiresGet) ->
     {IsNewEpoch, ActorId, State2} = maybe_new_key_epoch(Coord, State, OldObj, RObj),
-    case put_merge(Coord, LWW, OldObj, RObj, {IsNewEpoch, ActorId}, StartTime) of
+    DVV = proplists:get_value(dvv_enabled, BProps, true),
+    WriteOnce = proplists:get_value(write_once, BProps, true),
+    case put_merge(Coord, LWW, OldObj, RObj, {IsNewEpoch, ActorId}, StartTime, WriteOnce, DVV) of
         {oldobj, OldObj} ->
             {{false, {OldObj, unchanged_no_old_object}}, PutArgs, State2};
         {newobj, NewObj} ->
@@ -3324,9 +3328,9 @@ select_newest_content(Mult) ->
          Mult)).
 
 %% @private
-put_merge(false, true, _CurObj, UpdObj, _VId, _StartTime) -> % coord=false, LWW=true
+put_merge(false, true, _CurObj, UpdObj, _VId, _StartTime, _WO, _DVV) -> % coord=false, LWW=true
     {newobj, UpdObj};
-put_merge(false, false, CurObj, UpdObj, {NewEpoch, VId}, _StartTime) -> % coord=false, LWW=false
+put_merge(false, false, CurObj, UpdObj, {NewEpoch, VId}, _StartTime, _WO, _DVV) -> % coord=false, LWW=false
     %% a downstream merge, or replication of a coordinated PUT
     %% Merge the value received with local replica value
     %% and store the value IFF it is different to what we already have
@@ -3342,8 +3346,8 @@ put_merge(false, false, CurObj, UpdObj, {NewEpoch, VId}, _StartTime) -> % coord=
                     {newobj, ResObj}
             end
     end;
-put_merge(true, LWW, CurObj, UpdObj, {_NewEpoch, VId}, StartTime) ->
-    {newobj, riak_object:update(LWW, CurObj, UpdObj, VId, StartTime)}.
+put_merge(true, LWW, CurObj, UpdObj, {_NewEpoch, VId}, StartTime, WO, DVV) ->
+    {newobj, riak_object:update(LWW, CurObj, UpdObj, VId, StartTime, WO, DVV)}.
 
 %% @private
 do_get(_Sender, BKey, ReqID,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2918,8 +2918,8 @@ get_put_options(Options) ->
 
 get_put_options([], RR, CD, SW, RB, CO, BP) ->
     {RR, CD, SW, RB, CO, BP};
-get_put_options([{rr, RR}|Opts], _RR, CD, SW, RB, CO, BP) ->
-    get_put_options(Opts, RR, CD, SW, RB, CO, BP);
+get_put_options([rr|Opts], _RR, CD, SW, RB, CO, BP) ->
+    get_put_options(Opts, true, CD, SW, RB, CO, BP);
 get_put_options([coord|Opts], RR, _CD, SW, RB, CO, BP) ->
     get_put_options(Opts, RR, true, SW, RB, CO, BP);
 get_put_options([{sync_on_write, SW}|Opts], RR, CD, _SW, RB, CO, BP) ->
@@ -4288,7 +4288,7 @@ encode_and_put(
                     %% and errors themselves.
                     Mod:put_object(Bucket, Key, IndexSpecs, Obj, ModState);
                 false ->
-                    ObjFmt = object_format(Mod, ModState),
+                    ObjFmt = ?CAP_OBJECT_FORMAT,
                     EncodedVal = riak_object:to_binary(ObjFmt, Obj),
                     case size_check(DoMaxCheck, Coord, EncodedVal) of
                         {too_large, BinSize} ->
@@ -4326,7 +4326,8 @@ encode_and_put(
             end
     end.
 
-size_check(_, false, _EncodedVal) ->
+size_check(true, false, _EncodedVal) ->
+    % No need to do the check - the coordinator will check
     ok;
 size_check(true, true, EncodedVal) ->
     BinSize = size(EncodedVal),
@@ -4337,7 +4338,7 @@ size_check(true, true, EncodedVal) ->
         false ->
             size_check(false, true, BinSize)
     end;
-size_check(false, true, BinSize) when is_integer(BinSize) ->
+size_check(false, _Coord, BinSize) when is_integer(BinSize) ->
     WarnSize = app_helper:get_env(riak_kv, warn_object_size),
     case BinSize > WarnSize of
         true ->
@@ -4345,11 +4346,12 @@ size_check(false, true, BinSize) when is_integer(BinSize) ->
         false ->
             ok
     end;
-size_check(false, true, EncodedVal) ->
+size_check(false, Coord, EncodedVal) ->
     BinSize = size(EncodedVal),
-    size_check(false, true, BinSize).
+    size_check(false, Coord, BinSize).
 
-sibling_check(_, false, _Obj) ->
+sibling_check(true, false, _Obj) ->
+    % No need to do the check - the coordinator will check
     ok;
 sibling_check(true, true, Obj) ->
     NumSiblings = riak_object:value_count(Obj),
@@ -4360,7 +4362,7 @@ sibling_check(true, true, Obj) ->
         false ->
             sibling_check(false, true, NumSiblings)
     end;
-sibling_check(false, true, NumSiblings) when is_integer(NumSiblings) ->
+sibling_check(false, _Coord, NumSiblings) when is_integer(NumSiblings) ->
     WarnSiblings = app_helper:get_env(riak_kv, warn_siblings),
     case NumSiblings > WarnSiblings of
         true ->
@@ -4368,9 +4370,9 @@ sibling_check(false, true, NumSiblings) when is_integer(NumSiblings) ->
         false ->
             ok
     end;
-sibling_check(false, true, Obj) ->
+sibling_check(false, Coord, Obj) ->
     NumSiblings = riak_object:value_count(Obj),
-    sibling_check(false, true, NumSiblings).
+    sibling_check(false, Coord, NumSiblings).
 
 -spec select_put_fun(Mod::term(), ModState::term(), Sync::boolean()) -> fun().
 select_put_fun(Mod, ModState, Sync) ->
@@ -4390,15 +4392,6 @@ select_put_fun(Mod, ModState, Sync) ->
 uses_r_object(Mod, ModState, Bucket) ->
     {ok, Capabilities} = Mod:capabilities(Bucket, ModState),
     lists:member(uses_r_object, Capabilities).
-
-object_format(Mod, ModState) ->
-    {ok, Capabilities} = Mod:capabilities(ModState),
-    case lists:member(always_v1obj, Capabilities) of
-        true ->
-            v1;
-        false ->
-            ?CAP_OBJECT_FORMAT
-    end.
 
 sanitize_bkey({{<<"default">>, B}, K}) ->
     {B, K};
@@ -4990,9 +4983,5 @@ rollover_test_() ->
              ]}
     }.
 
-always_v1_test() ->
-    % Confirm that the leveled backend will always be a v1 object
-    ObjFmt = object_format(riak_kv_leveled_backend, undefined),
-    ?assertEqual(v1, ObjFmt).
 
 -endif.

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -3891,7 +3891,7 @@ nextgenrepl(_B, _K, _Obj, _Size, _Coord, _Enabled, _Limit) ->
     old_object(),
     binary()|use_object, 
         % cannot be use_object if object is use_binary
-    proplist:proplist() | undefined,
+    proplists:proplist() | undefined,
     state())
         -> ok.
 %% @doc

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -2865,14 +2865,8 @@ do_put(Sender, Request, State) ->
 %% @private
 %% upon receipt of a client-initiated put
 do_put(Sender, {Bucket, _Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
-    BProps =
-        case proplists:get_value(bucket_props, Options) of
-            undefined ->
-                riak_core_bucket:get_bucket(Bucket);
-            Props ->
-                Props
-        end,
-    ReadRepair = proplists:get_value(rr, Options, false),
+   {ReadRepair, Coord, SyncOnWrite, ReturnBody, CRDTOp, BucketProps} =
+        get_put_options(Options),
     PruneTime =
         case ReadRepair of
             true ->
@@ -2880,13 +2874,16 @@ do_put(Sender, {Bucket, _Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
             false ->
                 StartTime
         end,
-    Coord = proplists:get_value(coord, Options, false),
-    SyncOnWrite = proplists:get_value(sync_on_write, Options, undefined),
-    CRDTOp = proplists:get_value(counter_op, Options, proplists:get_value(crdt_op, Options, undefined)),
+    BProps = 
+        case BucketProps of
+            undefined ->
+                riak_kv_util:get_bucket_props(Bucket);
+            OptionProps ->
+                OptionProps
+        end,
     PutArgs = 
         #putargs{
-            returnbody =
-                proplists:get_value(returnbody,Options,false) orelse Coord,
+            returnbody = ReturnBody orelse Coord,
             coord=Coord,
             lww=proplists:get_value(last_write_wins, BProps, false),
             bkey=BKey,
@@ -2898,13 +2895,43 @@ do_put(Sender, {Bucket, _Key}=BKey, RObj, ReqID, StartTime, Options, State) ->
             prunetime=PruneTime,
             crdt_op = CRDTOp,
             sync_on_write = SyncOnWrite,
-            reason = put},
+            reason = put
+        },
     {PrepPutRes, UpdPutArgs, State2} = prepare_put(State, PutArgs),
     {Reply, UpdState} = perform_put(PrepPutRes, State2, UpdPutArgs),
     riak_core_vnode:reply(Sender, Reply),
 
     update_index_write_stats(UpdPutArgs#putargs.is_index, UpdPutArgs#putargs.index_specs),
     {Reply, UpdState}.
+
+
+get_put_options(Options) ->
+    get_put_options(
+        Options,
+        false,
+        false,
+        undefined,
+        false,
+        proplists:get_value(crdt_op, Options, undefined),
+        undefined
+    ).
+
+get_put_options([], RR, CD, SW, RB, CO, BP) ->
+    {RR, CD, SW, RB, CO, BP};
+get_put_options([{rr, RR}|Opts], _RR, CD, SW, RB, CO, BP) ->
+    get_put_options(Opts, RR, CD, SW, RB, CO, BP);
+get_put_options([coord|Opts], RR, _CD, SW, RB, CO, BP) ->
+    get_put_options(Opts, RR, true, SW, RB, CO, BP);
+get_put_options([{sync_on_write, SW}|Opts], RR, CD, _SW, RB, CO, BP) ->
+    get_put_options(Opts, RR, CD, SW, RB, CO, BP);
+get_put_options([{returnbody, RB}|Opts], RR, CD, SW, _RB, CO, BP) ->
+    get_put_options(Opts, RR, CD, SW, RB, CO, BP);
+get_put_options([{counter_op, CO}|Opts], RR, CD, SW, RB, _CO, BP) ->
+    get_put_options(Opts, RR, CD, SW, RB, CO, BP);
+get_put_options([{bucket_props, BP}|Opts], RR, CD, SW, RB, CO, _BP) ->
+    get_put_options(Opts, RR, CD, SW, RB, CO, BP);
+get_put_options([_Opts|Opts], RR, CD, SW, RB, CO, BP) ->
+    get_put_options(Opts, RR, CD, SW, RB, CO, BP).
 
 
 %% @doc Remove a tombstone, assuming the state of the object currently in the
@@ -3046,30 +3073,60 @@ prepare_put_existing_object(#state{idx =Idx} = State,
                              crdt_op = CRDTOp}=PutArgs,
                             OldObj, IndexBackend, CacheData, RequiresGet) ->
     {IsNewEpoch, ActorId, State2} = maybe_new_key_epoch(Coord, State, OldObj, RObj),
-    DVV = proplists:get_value(dvv_enabled, BProps, true),
-    WriteOnce = proplists:get_value(write_once, BProps, true),
-    case put_merge(Coord, LWW, OldObj, RObj, {IsNewEpoch, ActorId}, StartTime, WriteOnce, DVV) of
+    {DVV, WriteOnce, AllowMult} = get_put_properties(BProps),
+    MergeResult =
+        put_merge(
+            Coord,
+            LWW,
+            OldObj,
+            RObj,
+            {IsNewEpoch, ActorId},
+            StartTime,
+            WriteOnce,
+            DVV
+        ),
+    case MergeResult of
         {oldobj, OldObj} ->
             {{false, {OldObj, unchanged_no_old_object}}, PutArgs, State2};
         {newobj, NewObj} ->
-            case enforce_allow_mult(NewObj, OldObj, BProps) of
+            case enforce_allow_mult(NewObj, OldObj, AllowMult) of
                 {ok, AMObj} ->
                     IndexSpecs =
-                        get_index_specs(IndexBackend, CacheData, RequiresGet,
-                                        AMObj, OldObj),
+                        get_index_specs(
+                            IndexBackend, CacheData, RequiresGet, AMObj, OldObj
+                        ),
                     ObjToStore0 =
                         maybe_prune_vclock(PruneTime, AMObj, BProps),
                     ObjectToStore =
-                        maybe_do_crdt_update(Coord, CRDTOp, ActorId,
-                                                ObjToStore0),
-                    determine_put_result(ObjectToStore, OldObj, Idx,
-                                            PutArgs, State2,
-                                            IndexSpecs, IndexBackend);
+                        maybe_do_crdt_update(
+                            Coord, CRDTOp, ActorId, ObjToStore0),
+                    determine_put_result(
+                        ObjectToStore,
+                        OldObj,
+                        Idx,
+                        PutArgs,
+                        State2,
+                        IndexSpecs, IndexBackend
+                    );
                 {error, Reason} ->
                     ?LOG_ERROR("Error on allow_mult ~w", [Reason]),
                     {{fail, Idx, Reason}, PutArgs, State2}
             end
     end.
+
+get_put_properties(BProps) ->
+    get_put_properties(BProps, true, false, undefined).
+
+get_put_properties([], DVV, WriteOnce, AM) ->
+    {DVV, WriteOnce, AM};
+get_put_properties([{dvv_enabled, DVV}|Props], _DVV, WriteOnce, AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM);
+get_put_properties([{write_once, WriteOnce}|Props], DVV, _WriteOnce, AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM);
+get_put_properties([{allow_mult, AM}|Props], DVV, WriteOnce, _AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM);
+get_put_properties([_Prop|Props], DVV, WriteOnce, AM) ->
+    get_put_properties(Props, DVV, WriteOnce, AM).
 
 determine_put_result({error, E}, _, Idx, PutArgs, State, _IndexSpecs, _IndexBackend) ->
     {{fail, Idx, E}, PutArgs, State};
@@ -3324,11 +3381,9 @@ do_reformat({Bucket, Key}=BKey, State=#state{mod=Mod, modstate=ModState}) ->
 %% an object with multiple contents if allow_mult=false for that bucket
 %% Also provides a double check that the object is safe to store - its contents
 %% must not be empty, it should not be an object head.
-enforce_allow_mult(Obj, OldObj, BProps) ->
+enforce_allow_mult(Obj, OldObj, AllowMult) ->
     MergedContents = riak_object:get_contents(Obj),
-    case {proplists:get_value(allow_mult, BProps),
-            MergedContents,
-            riak_object:is_head(Obj)} of
+    case {AllowMult, MergedContents, riak_object:is_head(Obj)} of
         {_, [], _} ->
             % This is a known issue - 
             % https://github.com/basho/riak_kv/issues/1707
@@ -3821,7 +3876,7 @@ do_get_vclock({Bucket, Key}, Mod, ModState) ->
             riak_object:riak_object(),
             state()) -> {error, term(), state()}|{ok, state()}.
 do_handoff_put({Bucket, _Key}=BKey, HandoffObj, State) ->
-    BProps = riak_core_bucket:get_bucket(Bucket),
+    BProps = riak_kv_util:get_bucket_props(Bucket),
     PutArgs = 
         #putargs{
             returnbody = false,

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -3115,18 +3115,19 @@ prepare_put_existing_object(#state{idx =Idx} = State,
     end.
 
 get_put_properties(BProps) ->
-    get_put_properties(BProps, true, false, undefined).
+    {
+        keyfind(dvv_enabled, BProps, true),
+        keyfind(write_once, BProps, false),
+        keyfind(allow_mult, BProps, undefined)
+    }.
 
-get_put_properties([], DVV, WriteOnce, AM) ->
-    {DVV, WriteOnce, AM};
-get_put_properties([{dvv_enabled, DVV}|Props], _DVV, WriteOnce, AM) ->
-    get_put_properties(Props, DVV, WriteOnce, AM);
-get_put_properties([{write_once, WriteOnce}|Props], DVV, _WriteOnce, AM) ->
-    get_put_properties(Props, DVV, WriteOnce, AM);
-get_put_properties([{allow_mult, AM}|Props], DVV, WriteOnce, _AM) ->
-    get_put_properties(Props, DVV, WriteOnce, AM);
-get_put_properties([_Prop|Props], DVV, WriteOnce, AM) ->
-    get_put_properties(Props, DVV, WriteOnce, AM).
+keyfind(Key, BProps, Default) when is_atom(Key) ->
+    case lists:keyfind(Key, 1, BProps) of
+        {Key, Value} ->
+            Value;
+        _ ->
+            Default
+    end.
 
 determine_put_result({error, E}, _, Idx, PutArgs, State, _IndexSpecs, _IndexBackend) ->
     {{fail, Idx, E}, PutArgs, State};
@@ -4983,6 +4984,26 @@ rollover_test_() ->
              ]}
     }.
 
+roll_put_properties(BProps) ->
+    roll_put_properties(BProps, true, false, undefined).
+
+roll_put_properties([], DVV, WriteOnce, AM) ->
+    {DVV, WriteOnce, AM};
+roll_put_properties([{dvv_enabled, DVV}|Props], _DVV, WriteOnce, AM) ->
+    roll_put_properties(Props, DVV, WriteOnce, AM);
+roll_put_properties([{write_once, WriteOnce}|Props], DVV, _WriteOnce, AM) ->
+    roll_put_properties(Props, DVV, WriteOnce, AM);
+roll_put_properties([{allow_mult, AM}|Props], DVV, WriteOnce, _AM) ->
+    roll_put_properties(Props, DVV, WriteOnce, AM);
+roll_put_properties([_Prop|Props], DVV, WriteOnce, AM) ->
+    roll_put_properties(Props, DVV, WriteOnce, AM).
+
+keyfind_fetcher(DProps) ->
+    {
+        keyfind(dvv_enabled, DProps, true),
+        keyfind(write_once, DProps, false),
+        keyfind(allow_mult, DProps, undefined)
+    }.
 
 proplist_fetcher(DProps) ->
     {
@@ -5028,37 +5049,50 @@ speed_test() ->
             {chash_keyfun,{riak_core_util,chash_std_keyfun}}
         ],
     
-        {TC0, R0} =
-            timer:tc(
-                fun() ->
-                    lists:map(
-                        fun(_I) -> get_put_properties(DefaultProps) end,
-                        lists:seq(1, 100000)
-                    )
-                end
-            ),
-        {TC1, R1} =
-            timer:tc(
-                fun() ->
-                    lists:map(
-                        fun(_I) -> proplist_fetcher(DefaultProps) end,
-                        lists:seq(1, 100000)
-                    )
-                end
-            ),
-        {TC2, R2} =
-            timer:tc(
-                fun() ->
-                    lists:map(
-                        fun(_I) -> map_fetcher(DefaultProps) end,
-                        lists:seq(1, 100000)
-                    )
-                end
-            ),
-        ?assertMatch(R0, R1),
-        ?assertMatch(R0, R2),
-        io:format(user, "Speed compare ~w ~w ~w~n", [TC0, TC1, TC2])
-    .
+    {TC0, R0} =
+        timer:tc(
+            fun() ->
+                lists:map(
+                    fun(_I) -> roll_put_properties(DefaultProps) end,
+                    lists:seq(1, 100000)
+                )
+            end
+        ),
+    {TC1, R1} =
+        timer:tc(
+            fun() ->
+                lists:map(
+                    fun(_I) -> proplist_fetcher(DefaultProps) end,
+                    lists:seq(1, 100000)
+                )
+            end
+        ),
+    {TC2, R2} =
+        timer:tc(
+            fun() ->
+                lists:map(
+                    fun(_I) -> map_fetcher(DefaultProps) end,
+                    lists:seq(1, 100000)
+                )
+            end
+        ),
+    {TC3, R3} =
+        timer:tc(
+            fun() ->
+                lists:map(
+                    fun(_I) -> keyfind_fetcher(DefaultProps) end,
+                    lists:seq(1, 100000)
+                )
+            end
+        ),
+    ?assertMatch(R0, R1),
+    ?assertMatch(R0, R2),
+    ?assertMatch(R0, R3),
+    io:format(
+        user,
+        "Speed compare ~w ~w ~w ~w~n",
+        [TC0, TC1, TC2, TC3]
+    ).
 
 
 -endif.

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -94,7 +94,7 @@
 -export([hash/1, hash/2, hash/4, approximate_size/2, proxy_size/1]).
 -export([vclock_encoding_method/0, vclock/1, vclock_header/1, encode_vclock/1, decode_vclock/1]).
 -export([encode_vclock/2, decode_vclock/2]).
--export([update/5, update_value/2, update_metadata/2, bucket/1, bucket_only/1, type/1, value_count/1]).
+-export([update/7, update_value/2, update_metadata/2, bucket/1, bucket_only/1, type/1, value_count/1]).
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
 -export([merge/2, apply_updates/1, syntactic_merge/2]).
 -export([to_json/1, from_json/1]).
@@ -440,6 +440,16 @@ compare_content_dates(C1,C2) ->
             C1 < C2
     end.
 
+
+-spec merge(riak_object(), riak_object()) -> riak_object().
+merge(OldObject, NewObject) ->
+    Bucket = bucket(OldObject),
+    merge(
+        OldObject,
+        NewObject,
+        riak_kv_util:get_write_once(Bucket),
+        dvv_enabled(Bucket)).
+
 %% @doc  Merge the contents and vclocks of OldObject and NewObject.
 %%       Note: This function calls apply_updates on NewObject.
 %%       Depending on whether DVV is enabled or not, then may merge
@@ -448,17 +458,15 @@ compare_content_dates(C1,C2) ->
 %%       merge, this is also now a semantic merge for CRDTs.  Only
 %%       call with concurrent objects. Use `syntactic_merge/2' if one
 %%       object may strictly dominate another.
--spec merge(riak_object(), riak_object()) -> riak_object().
-merge(OldObject=#r_object{}, NewObject=#r_object{}) ->
+-spec merge(riak_object(), riak_object(), boolean(), boolean()) -> riak_object().
+merge(OldObject=#r_object{}, NewObject=#r_object{}, WriteOnce, DVV) ->
     NewObj1 = apply_updates(NewObject),
-    Bucket = bucket(OldObject),
-    case riak_kv_util:get_write_once(Bucket) of
+    case WriteOnce of
         true ->
             merge_write_once(OldObject, NewObj1);
         _ ->
-            DVV = dvv_enabled(Bucket),
-            {Time,  {CRDT, Contents}} = timer:tc(fun merge_contents/3,
-                                                 [NewObject, OldObject, DVV]),
+            {Time,  {CRDT, Contents}} =
+                timer:tc(fun merge_contents/3, [NewObject, OldObject, DVV]),
             ok = riak_kv_stat:update({riak_object_merge, CRDT, Time}),
             OldObject#r_object{contents=Contents,
                 vclock=vclock:merge([OldObject#r_object.vclock,
@@ -950,12 +958,18 @@ increment_vclock(Object=#r_object{bucket=B}, ClientId) ->
 %% @doc  Increment the entry for ClientId in O's vclock.
 -spec increment_vclock(riak_object(), vclock:vclock_node(), vclock:timestamp()) -> riak_object().
 increment_vclock(Object=#r_object{bucket=B}, ClientId, Timestamp) ->
+    increment_vclock(Object, ClientId, Timestamp, dvv_enabled(B)).
+
+-spec increment_vclock(
+    riak_object(), vclock:vclock_node(), vclock:timestamp(), boolean())
+        -> riak_object().
+increment_vclock(Object, ClientId, Timestamp, DVV) ->
     NewClock = vclock:increment(ClientId, Timestamp, Object#r_object.vclock),
     {ok, Dot} = vclock:get_dot(ClientId, NewClock),
     %% If it is true that we only ever increment the vclock to create
     %% a frontier object, then there must only ever be a single value
     %% when we increment, so add the dot here.
-    assign_dot(Object#r_object{vclock=NewClock}, Dot, dvv_enabled(B)).
+    assign_dot(Object#r_object{vclock=NewClock}, Dot, DVV).
 
 %% @doc Prune vclock
 -spec prune_vclock(riak_object(), vclock:timestamp(), [proplists:property()]) ->
@@ -1100,16 +1114,18 @@ is_updated(_Object=#r_object{updatemetadata=M,updatevalue=V}) ->
             end
     end.
 
-%% @doc a Put merge. Update a stored riak_object with the value from a
-%% new riak_object that has been put. Must be serialised by the
-%% `Actor' provided.
--spec update(LWW :: boolean(), LocalObj :: riak_object(),
-             NewObj :: riak_object(), Actor ::vclock:vclock_node(),
-             TimeStamp :: vclock:timestamp()) ->
-                    riak_object().
-update(true, _OldObject, NewObject=#r_object{}, Actor, Timestamp) ->
-    increment_vclock(NewObject, Actor, Timestamp);
-update(false, OldObject=#r_object{}, NewObject=#r_object{}, Actor, Timestamp) ->
+-spec update(
+    LWW :: boolean(),
+    LocalObj :: riak_object(),
+    NewObj :: riak_object(),
+    Actor ::vclock:vclock_node(),
+    TimeStamp :: vclock:timestamp(),
+    WriteOnce ::boolean(),
+    DVV :: boolean()) ->
+        riak_object().
+update(true, _OldObject, NewObject=#r_object{}, Actor, Timestamp, _WriteOnce, DVV) ->
+    increment_vclock(NewObject, Actor, Timestamp, DVV);
+update(false, OldObject=#r_object{}, NewObject=#r_object{}, Actor, Timestamp, WriteOnce, DVV) ->
     %% Get the vclock we have for the local / old object
     LocalVC = vclock(OldObject),
     %% get the vclock from the new object
@@ -1120,7 +1136,7 @@ update(false, OldObject=#r_object{}, NewObject=#r_object{}, Actor, Timestamp) ->
     %% clock and overwrite.
     case vclock:descends(PutVC, LocalVC) of
         true ->
-            increment_vclock(NewObject, Actor, Timestamp);
+            increment_vclock(NewObject, Actor, Timestamp, DVV);
         false ->
             %% The new object is concurrent with some other value, so
             %% merge the new object and the old object.
@@ -1128,9 +1144,8 @@ update(false, OldObject=#r_object{}, NewObject=#r_object{}, Actor, Timestamp) ->
             FrontierClock = vclock:increment(Actor, Timestamp, MergedClock),
             {ok, Dot} = vclock:get_dot(Actor, FrontierClock),
             %% Assign an event to the new value
-            Bucket = bucket(OldObject),
-            DottedPutObject = assign_dot(NewObject, Dot, dvv_enabled(Bucket)),
-            MergedObject = merge(DottedPutObject, OldObject),
+            DottedPutObject = assign_dot(NewObject, Dot, DVV),
+            MergedObject = merge(DottedPutObject, OldObject, WriteOnce, DVV),
             set_vclock(MergedObject, FrontierClock)
     end.
 
@@ -1150,7 +1165,8 @@ syntactic_merge(CurrentObject, NewObject) ->
                   end,
 
     case ancestors([UpdatedCurr, UpdatedNew]) of
-        [] -> merge(UpdatedCurr, UpdatedNew);
+        [] ->
+            merge(UpdatedCurr, UpdatedNew);
         [Ancestor] ->
             case equal(Ancestor, UpdatedCurr) of
                 true  -> UpdatedNew;

--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -88,7 +88,8 @@
 -define(EMPTY_VTAG_BIN, <<"e">>).
 
 -export([new/3, new/4, ensure_robject/1, ancestors/1, reconcile/2, equal/2, remove_dominated/1]).
--export([increment_vclock/2, increment_vclock/3, prune_vclock/3, vclock_descends/2, all_actors/1]).
+-export([increment_vclock/2, increment_vclock/3, increment_vclock/4]).
+-export([prune_vclock/3, vclock_descends/2, all_actors/1]).
 -export([actor_counter/2]).
 -export([key/1, get_metadata/1, get_metadatas/1, get_values/1, get_value/1, get_dotted_values/1]).
 -export([hash/1, hash/2, hash/4, approximate_size/2, proxy_size/1]).
@@ -96,7 +97,7 @@
 -export([encode_vclock/2, decode_vclock/2]).
 -export([update/7, update_value/2, update_metadata/2, bucket/1, bucket_only/1, type/1, value_count/1]).
 -export([get_update_metadata/1, get_update_value/1, get_contents/1]).
--export([merge/2, apply_updates/1, syntactic_merge/2]).
+-export([merge/2, apply_updates/1, syntactic_merge/2, syntactic_merge/3]).
 -export([to_json/1, from_json/1]).
 -export([index_data/1, diff_index_data/2]).
 -export([index_specs/1, diff_index_specs/2]).
@@ -1151,6 +1152,12 @@ update(false, OldObject=#r_object{}, NewObject=#r_object{}, Actor, Timestamp, Wr
 
 -spec syntactic_merge(riak_object(), riak_object()) -> riak_object().
 syntactic_merge(CurrentObject, NewObject) ->
+    syntactic_merge(CurrentObject, NewObject, undefined).
+
+-spec syntactic_merge(
+    riak_object(), riak_object(), {boolean(), boolean()}|undefined)
+    -> riak_object().
+syntactic_merge(CurrentObject, NewObject, Flags) ->
     %% Paranoia in case objects were incorrectly stored
     %% with update information.  Vclock is not updated
     %% but since no data is lost the objects will be
@@ -1164,10 +1171,12 @@ syntactic_merge(CurrentObject, NewObject) ->
                       false -> CurrentObject
                   end,
 
-    case ancestors([UpdatedCurr, UpdatedNew]) of
-        [] ->
+    case {ancestors([UpdatedCurr, UpdatedNew]), Flags} of
+        {[], undefined} ->
             merge(UpdatedCurr, UpdatedNew);
-        [Ancestor] ->
+        {[], {WriteOnce, DVVEnabled}} ->
+            merge(UpdatedCurr, UpdatedNew, WriteOnce, DVVEnabled);
+        {[Ancestor], _} ->
             case equal(Ancestor, UpdatedCurr) of
                 true  -> UpdatedNew;
                 false -> UpdatedCurr


### PR DESCRIPTION
Reduce the number of re-requests for the bucket property in the PUT path.

Running the `general_counter_perf` test, this branch reduces the calls to `ets:lookup/2` from 115 to 65.  Primarily by fetching the bucket properties once at the start of the PUT, and re-using the properties throughout the PUT process (rather than re-requesting them via ETS lookups).