### PR TITLE
Fix compatibility with OTP 25

### DIFF
--- a/priv/tracers/tracer_accumulating_time.erl
+++ b/priv/tracers/tracer_accumulating_time.erl
@@ -35,9 +35,17 @@ start(Pid_list, MFA_list, IntervalMS) ->
     {started, TPid}.
 
 stop() ->
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace_ts, Pid, call, {Mod, Func, Arity}, TS}, {Dict}) ->
     MFA = {Mod, Func, Arity},

--- a/priv/tracers/tracer_backend_latency.erl
+++ b/priv/tracers/tracer_backend_latency.erl
@@ -129,9 +129,17 @@ stop() ->
     %% io:format("Histogram stats:\n~p\n", [catch folsom_metrics:get_histogram_statistics(foo)]),
     %% catch folsom_metrics:delete_metric(foo),
 
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace_ts, Pid, call, {riak_kv_put_fsm, init, _}, TS}, {Dict, LMS}) ->
     {dict:store({put, Pid}, TS, Dict), LMS};

--- a/priv/tracers/tracer_eleveldb_put_size.erl
+++ b/priv/tracers/tracer_eleveldb_put_size.erl
@@ -40,9 +40,17 @@ start(Interval) ->
     {started, TPid}.
 
 stop() ->
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace, _Pid, call, {eleveldb, write, [_, PutList, _]}},
       {StatName, SumBytes}) ->

--- a/priv/tracers/tracer_fsm_init.erl
+++ b/priv/tracers/tracer_fsm_init.erl
@@ -44,9 +44,17 @@ start(Interval) ->
     {started, TPid}.
 
 stop() ->
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace, _Pid, call, {riak_kv_put_fsm, start_link, _}},
       {Pstart_link, R, P, B, E, I, K}) ->

--- a/priv/tracers/tracer_func_args.erl
+++ b/priv/tracers/tracer_func_args.erl
@@ -78,10 +78,18 @@ stop() ->
     TotalCalls = lists:sum([Count || {_Arg, Count} <- Res]),
     io:format("Total calls: ~p\n", [TotalCalls]),
     io:format("Call stats:\n~p\n", [catch lists:sort(Sort, Res)]),
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     timer:sleep(100),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace, _Pid, call, {_, _, Args}}, {Tab, ArgMangler} = Acc) ->
     Args2 = ArgMangler(Args),

--- a/priv/tracers/tracer_gc_latency.erl
+++ b/priv/tracers/tracer_gc_latency.erl
@@ -35,11 +35,19 @@ start(LatencyMS) ->
     {started, TPid}.
 
 stop() ->
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     timer:sleep(100),
     catch folsom_metrics:delete_metric(foo),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace_ts, Pid, gc_start, _Stats, TS}, {Dict, LMS}) ->
     {dict:store(Pid, TS, Dict), LMS};

--- a/priv/tracers/tracer_latency_histogram.erl
+++ b/priv/tracers/tracer_latency_histogram.erl
@@ -95,11 +95,19 @@ start(Mod, Func, Arity, RunSeconds) ->
 
 stop() ->
     io:format("Histogram stats:\n~p\n", [catch folsom_metrics:get_histogram_statistics(foo)]),
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     timer:sleep(100),
     catch folsom_metrics:delete_metric(foo),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace_ts, Pid, call, {_, _, _}, TS}, {Dict, LMS}) ->
     {dict:store(Pid, TS, Dict), LMS};

--- a/priv/tracers/tracer_merge_and_and_handoff.erl
+++ b/priv/tracers/tracer_merge_and_and_handoff.erl
@@ -43,9 +43,17 @@ start(Interval) ->
     {started, TPid}.
 
 stop() ->
-    dbg:stop_clear(),
+    stop_clear(),
     catch exit(element(2,dbg:get_tracer()), kill),
     stopped.
+
+-if(?OTP_RELEASE >= 25).
+stop_clear() ->
+    dbg:stop().
+-else.
+stop_clear() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace, _Pid, call, {bitcask, merge_single_entry,
                            [K, V, _TS, _FId, {File,_,_,_}, _State]}},

--- a/priv/tracers/tracer_timeit.erl
+++ b/priv/tracers/tracer_timeit.erl
@@ -42,7 +42,13 @@ timeit(Mod, Fun, Arity, Type) ->
     dbg:p(all, call),
     dbg:tpl(Mod, Fun, Arity, [{'_', [], [{return_trace}]}]).
 
-stop() -> dbg:stop_clear().
+-if(?OTP_RELEASE >= 25).
+stop() ->
+    dbg:stop().
+-else.
+stop() ->
+    dbg:stop_clear().
+-endif.
 
 trace({trace, Pid, call, {Mod, Fun, _}}, {D, {all, {Count, Max}}}) ->
     D2 = orddict:store({Pid, Mod, Fun}, os:timestamp(), D),

--- a/src/riak_kv_bitcask_backend.erl
+++ b/src/riak_kv_bitcask_backend.erl
@@ -230,7 +230,7 @@ get(Bucket, Key, #state{ref=Ref, key_vsn=KVers}=State) ->
 %% NOTE: The bitcask backend does not currently support
 %% secondary indexing and the_IndexSpecs parameter
 %% is ignored.
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-type index_spec() :: {add, Index::any(), SecondaryKey::any()} | {remove, Index::any(), SecondaryKey::any()}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.

--- a/src/riak_kv_eleveldb_backend.erl
+++ b/src/riak_kv_eleveldb_backend.erl
@@ -177,7 +177,7 @@ get(Bucket, Key, #state{read_opts=ReadOpts,
             {error, Reason, State}
     end.
 
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-type index_spec() :: {add, Index::any(), SecondaryKey::any()} | {remove, Index::any(), SecondaryKey::any()}.
 
 %% @doc Normal put, use existing option, do not modify write options
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -236,8 +236,8 @@ head(Bucket, Key, #state{bookie=Bookie}=State) ->
     end.
 
 %% @doc Insert an object into the leveled backend.
--type index_spec() :: {add, Index, SecondaryKey} |
-                        {remove, Index, SecondaryKey}.
+-type index_spec() :: {add, Index::any(), SecondaryKey::any()} |
+                        {remove, Index::any(), SecondaryKey::any()}.
 
 -spec flush_put(riak_object:bucket(),
                     riak_object:key(),

--- a/src/riak_kv_memory_backend.erl
+++ b/src/riak_kv_memory_backend.erl
@@ -208,7 +208,7 @@ get(Bucket, Key, State=#state{data_ref=DataRef,
     end.
 
 %% @doc Insert an object into the memory backend.
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-type index_spec() :: {add, Index::any(), SecondaryKey::any()} | {remove, Index::any(), SecondaryKey::any()}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()}.
 put(Bucket, PrimaryKey, IndexSpecs, Val, State=#state{data_ref=DataRef,

--- a/src/riak_kv_multi_backend.erl
+++ b/src/riak_kv_multi_backend.erl
@@ -257,7 +257,7 @@ head(Bucket, Key, State) ->
 
 %% @doc Insert an object with secondary index
 %% information into the kv backend
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-type index_spec() :: {add, Index::any(), SecondaryKey::any()} | {remove, Index::any(), SecondaryKey::any()}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.

--- a/src/riak_kv_multi_prefix_backend.erl
+++ b/src/riak_kv_multi_prefix_backend.erl
@@ -294,7 +294,7 @@ head(Bucket, Key, State) ->
 
 %% @doc Insert an object with secondary index
 %% information into the kv backend
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-type index_spec() :: {add, Index::any(), SecondaryKey::any()} | {remove, Index::any(), SecondaryKey::any()}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()} |
                  {error, term(), state()}.

--- a/src/riak_kv_yessir_backend.erl
+++ b/src/riak_kv_yessir_backend.erl
@@ -272,7 +272,7 @@ make_get_return_val(RObj, false = _WantsBinary, #state{op_get = Gets} = S) ->
     {ok, RObj, S#state{op_get = Gets + 1}}.
 
 %% @doc Store an object, yes, sir!
--type index_spec() :: {add, Index, SecondaryKey} | {remove, Index, SecondaryKey}.
+-type index_spec() :: {add, Index::any(), SecondaryKey::any()} | {remove, Index::any(), SecondaryKey::any()}.
 -spec put(riak_object:bucket(), riak_object:key(), [index_spec()], binary(), state()) ->
                  {ok, state()}.
 put(_Bucket, _PKey, _IndexSpecs, _Val, #state{op_put = Puts} = S) ->


### PR DESCRIPTION
As of OTP 25, dbg:stop/0 should be used instead of dbg:stop_clear/0. The dbg:stop_clear/0 function is deprecated in OTP 26 and later.

This also fixes some type declaration warnings.