### PR TITLE
Default must be of first type in list

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -1731,7 +1731,7 @@
 %% timout is limited to 5 minutes.
 {mapping, "delete_mode", "riak_kv.delete_mode", [
   {default, 3000},
-  {datatype, [{atom, keep}, {atom, immediate}, integer]},
+  {datatype, [integer, {atom, keep}, {atom, immediate}]},
   {validators, ["delete_mode_validator"]}
 ]}.
 


### PR DESCRIPTION
If there is a list of types, the default must be of the first type in the list.

This is assumed in the `cuttlefish_conf` module `generate_comments/1` function

https://github.com/OpenRiak/riak_kv/issues/68

Will fail when cuttlefish generates a file, but not in unit tests.