### PR TITLE
Don't use compiled regex unless on local node

### DIFF
--- a/src/riak_kv_backend.erl
+++ b/src/riak_kv_backend.erl
@@ -28,14 +28,10 @@
     :: fun((binary(), any()) -> any() | no_return()).
 -type fold_keys_fun()
     :: 
-        fun(
-            (riak_object:bucket(), riak_object:key(), fold_acc())
-                -> fold_acc() | no_return()
-            ) |
-        fun(
-            (riak_object:bucket(), {binary(), riak_object:key()}, fold_acc()
-                ) -> fold_acc() | no_return()
-            ).
+        fun((riak_object:bucket(), riak_object:key(), fold_acc())
+            -> fold_acc() | no_return()) |
+        fun((riak_object:bucket(), {binary(), riak_object:key()}, fold_acc())
+            -> fold_acc() | no_return()).
 -type fold_objects_fun()
     :: fun((binary(), binary(), term(), any()) -> any() | no_return()).
 
@@ -167,7 +163,7 @@
         fold_keys_fun(),
         fold_acc(),
         riak_object:bucket(),
-        riak_kv_query:evaluated_query(),
+        riak_kv_query:query_definition(),
         boolean()|binary(),
         fold_opts(),
         state()

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -609,7 +609,7 @@ fold_heads(FoldHeadsFun, Acc, Opts, #state{bookie=Bookie}) ->
     riak_kv_backend:fold_keys_fun(),
     riak_kv_backend:fold_acc(),
     riak_object:bucket(),
-    riak_kv_query:evaluated_query(),
+    riak_kv_query:query_definition(),
     binary() | boolean(),
     riak_kv_backend:fold_opts(),
     state()
@@ -619,11 +619,18 @@ complex_query(
     {async, FoldFun} =
         case Query of
             {QueryComboFun, SubQueries} ->
+                SubQueries0 =
+                    lists:map(
+                        fun({AT, {IF, ST, ET, Expr}}) ->
+                            {AT, {IF, ST, ET, maybe_use_compiled_regex(Expr)}}
+                        end,
+                        SubQueries
+                    ),
                 leveled_bookie:book_multiindexfold(
                     State#state.bookie,
                     Bucket,
                     {FoldTermsFun, InitAcc},
-                    SubQueries,
+                    SubQueries0,
                     QueryComboFun
                 );
             {IdxField, {StartTerm, ExclusiveSK}, EndTerm, TermExpression} ->
@@ -632,7 +639,7 @@ complex_query(
                     {Bucket, leveled_codec:next_key(ExclusiveSK)},
                     {FoldTermsFun, InitAcc},
                     {IdxField, StartTerm, EndTerm},
-                    {ReturnTerms, TermExpression}
+                    {ReturnTerms, maybe_use_compiled_regex(TermExpression)}
                 );
             {IdxField, StartTerm, EndTerm, TermExpression} ->
                 leveled_bookie:book_indexfold(
@@ -640,7 +647,7 @@ complex_query(
                     {Bucket, <<>>},
                     {FoldTermsFun, InitAcc},
                     {IdxField, StartTerm, EndTerm},
-                    {ReturnTerms, TermExpression}
+                    {ReturnTerms, maybe_use_compiled_regex(TermExpression)}
                 )
         end,
     SnapPreFold = lists:member(snap_prefold, FoldOpts),
@@ -652,6 +659,18 @@ complex_query(
         _ ->
             {ok, FoldFun}
     end.
+
+-spec maybe_use_compiled_regex(
+    riak_kv_query:term_expression()) ->
+        riak_kv_query:query_expression()|riak_kv_query:plain_regex()|undefined.
+maybe_use_compiled_regex({regex, _PR, {N, CompiledRegex}}) when N == node() ->
+    CompiledRegex;
+maybe_use_compiled_regex({regex, PlainRegex, {exported, _ER}}) ->
+    PlainRegex;
+maybe_use_compiled_regex({regex, PlainRegex, {_N, _CR}}) ->
+    PlainRegex;
+maybe_use_compiled_regex(OtherExpression) ->
+    OtherExpression.
 
 %% @doc Delete all objects from this leveled backend
 -spec drop(state()) -> {ok, state()} | {error, term(), state()}.

--- a/src/riak_kv_query.erl
+++ b/src/riak_kv_query.erl
@@ -74,8 +74,15 @@
     fun((binary(), binary()) -> #{binary() => capture_value()}).
 -type query_expression() :: 
     {query, query_eval_fun(), query_filter_fun()}.
--type actual_regex() ::
-    {re_pattern, term(), term(), term(), term()}.
+-type plain_regex() :: iodata().
+-type exported_regex() :: {exported, term()}.
+    %% Not supported prior to OTP 28.1.  Then the type should be changed to
+    %% {exported, re:exported()}.
+-type compiled_regex() ::
+    {node(), {re_pattern, term(), term(), term(), term()}} |
+    exported_regex().
+-type actual_regex() :: 
+    {regex, plain_regex(), compiled_regex()|none}.
 -type term_expression() ::
     actual_regex()|undefined|query_expression().
 
@@ -168,6 +175,8 @@
         accumulation_option/0,
         query_expression/0,
         term_expression/0,
+        compiled_regex/0,
+        plain_regex/0,
         evaluated_query/0,
         validation_error/0,
         query_definition/0,
@@ -554,7 +563,15 @@ evaluate_query(single, {_AT, IN, ST, ET, RE, EE, FE}, Subs) ->
                         {REOnly, undefined, undefined} ->
                             case re:compile(REOnly) of
                                 {ok, MP} ->
-                                    {ok, {IN, ST, ET, MP}};
+                                    {
+                                        ok,
+                                        {
+                                            IN,
+                                            ST,
+                                            ET,
+                                            {regex, REOnly, {node(), MP}}
+                                        }
+                                    };
                                 {error, ErrSpec} ->
                                     ?LOG_WARNING(
                                         "Invalid regular expression "


### PR DESCRIPTION
Prepare the groundwork for non-local exported regex to be available in OTP 28.

Fixes the `riak_kv_backend:complex_query/7` spec (which was incorrect, the spec is not changed by the PR)