### PR TITLE
Use metadata_fetch not dict for vtag check

### DIFF
--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -687,7 +687,7 @@
 %% Legacy version is v0.
 %% Version v1 has improved performance, but all nodes in cluster will need
 %% to support version 1 before this can be enabled.  v1 is introduced with
-%% Riak 3.4
+%% Riak 3.4.0 - but should not be enabled prior to Riak 3.4.1
 %% From Riak 4.0 option will be removed, and all metadata will use v1.
 {mapping, "metadata.format", "riak_kv.metadata_version", [
   {default, v0},

--- a/src/riak_kv_wm_object.erl
+++ b/src/riak_kv_wm_object.erl
@@ -954,15 +954,20 @@ resource_exists(RD, Ctx0) ->
                     case DocCtx#ctx.vtag of
                         undefined ->
                             {true, RD, DocCtx};
-                        Vtag ->
-                            MDs = riak_object:get_metadatas(Doc),
-                            {lists:any(
+                        VTag ->
+                            VtagMatchesASibling =
+                                lists:any(
                                     fun(M) ->
-                                        dict:fetch(?MD_VTAG, M) =:= Vtag
+                                        SibTag =
+                                            riak_object:metadata_fetch(
+                                                ?MD_VTAG,
+                                                M
+                                            ),
+                                        VTag == SibTag
                                     end,
-                                    MDs),
-                                RD,
-                                DocCtx#ctx{vtag=Vtag}}
+                                    riak_object:get_metadatas(Doc)
+                                ),
+                            {VtagMatchesASibling, RD, DocCtx}
                     end;
                 {error, _} ->
                     %% This should never actually be reached because all the


### PR DESCRIPTION
An example of the use of dict() missed when updating for vi metadata