### PR TITLE
riak admin vnode status in JSON format, clique-conformant

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -390,3 +390,5 @@ subproc
 lz
 edates
 unsync'd
+sed
+json_pp

--- a/docs/OperationsAndTroubleshootingGuide.md
+++ b/docs/OperationsAndTroubleshootingGuide.md
@@ -314,6 +314,17 @@ All timings are internal timings, and not necessarily fully representative of ex
 
 The stats represent the statistics on the node from which they were requested.  The stats are not cluster-wide, they are always node aggregates e.g. the vnode stats are accumulated over every vnode on the node.
 
+### Vnode Status
+{: .d-inline-block }
+
+Available from Riak 3.4.1
+{: .label .label-purple }
+
+A significant proportion of the work within Riak takes places within the vnode.  To see the status of each vnode in the cluster, and see available statistics from the backend:  `riak admin vnode-status | sed -n 1p | json_pp`
+
+To look at the statistics from specific nodes or partitions see: `riak admin vnode-status --help`.
+
+
 ## Monitoring Operational Services
 
 ### Monitoring Anti-Entropy

--- a/src/riak_kv_cli_registry.erl
+++ b/src/riak_kv_cli_registry.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2025 TI Tokyo.  All Rights Reserved.
+%% Copyright (c) 2025, 2026 TI Tokyo.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file
@@ -20,7 +20,9 @@
 
 -module(riak_kv_cli_registry).
 
--define(CLI_MODULES, [riak_kv_tictacaae_cli]).
+-define(CLI_MODULES, [riak_kv_tictacaae_cli,
+                      riak_kv_vnode_status_cli
+                     ]).
 
 -export([register_cli/0
         ]).

--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -29,7 +29,6 @@
          leave/1,
          remove/1,
          status/1,
-         vnode_status/1,
          reip/1,
          reip_manual/1,
          ringready/1,
@@ -194,25 +193,6 @@ status([]) ->
             ?LOG_ERROR("Status failed ~p:~p", [Exception,
                     Reason]),
             io:format("Status failed, see log for details~n"),
-            error
-    end.
-
--spec(vnode_status([]) -> ok).
-vnode_status([]) ->
-    try
-        case riak_kv_status:vnode_status() of
-            [] ->
-                io:format("There are no active vnodes.~n");
-            Statuses ->
-                io:format("~s~n-------------------------------------------~n~n",
-                          ["Vnode status information"]),
-                print_vnode_statuses(lists:sort(Statuses))
-        end
-    catch
-        Exception:Reason ->
-            ?LOG_ERROR("Backend status failed ~p:~p", [Exception,
-                    Reason]),
-            io:format("Backend status failed, see log for details~n"),
             error
     end.
 
@@ -836,38 +816,6 @@ atomify_nodestrs(Strs) ->
                                          Acc
                                      end
                 end, [], Strs).
-
-print_vnode_statuses([]) ->
-    ok;
-print_vnode_statuses([{VNodeIndex, StatusData} | RestStatuses]) ->
-    io:format("VNode: ~p~n", [VNodeIndex]),
-    print_vnode_status(StatusData),
-    io:format("~n"),
-    print_vnode_statuses(RestStatuses).
-
-print_vnode_status([]) ->
-    ok;
-print_vnode_status([{backend_status,
-                     Backend,
-                     StatusItem} | RestStatusItems]) ->
-    if is_binary(StatusItem) ->
-            StatusString = binary_to_list(StatusItem),
-            io:format("Backend: ~p~nStatus: ~n~s~n",
-                      [Backend, string:strip(StatusString)]);
-       true ->
-            io:format("Backend: ~p~nStatus: ~n~p~n",
-                      [Backend, StatusItem])
-    end,
-    print_vnode_status(RestStatusItems);
-print_vnode_status([StatusItem | RestStatusItems]) ->
-    if is_binary(StatusItem) ->
-            StatusString = binary_to_list(StatusItem),
-            io:format("Status: ~n~s~n",
-                      [string:strip(StatusString)]);
-       true ->
-            io:format("Status: ~n~p~n", [StatusItem])
-    end,
-    print_vnode_status(RestStatusItems).
 
 bucket_error_xlate(Errors) when is_list(Errors) ->
     string:join(

--- a/src/riak_kv_leveled_backend.erl
+++ b/src/riak_kv_leveled_backend.erl
@@ -702,11 +702,10 @@ hot_backup(#state{bookie=Bookie, partition=Partition, db_path=DBP}, BackupRoot) 
 
 %% @doc Get the status information for this leveled backend
 -spec status(state()) -> [{atom(), term()}].
-status(_State) ->
-    % TODO: not yet implemented
+status(#state{bookie = Bookie}) ->
     % We can run the bucket stats query getting all stats, but this would not
     % mean an immediate response (and how frequently is this called?)
-    [].
+    maps:to_list(leveled_bookie:book_status(Bookie)).
 
 %% @doc Get an estimate of the data_size for this leveled backend
 -spec data_size(state()) ->

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -25,7 +25,6 @@
 -include_lib("kernel/include/logger.hrl").
 
 -export([register_cli/0]).
--export([vnode_status_on_nodes/2, tableify/1, tableify1/1]).
 
 register_cli() ->
     register_all_usage(),
@@ -61,7 +60,7 @@ get_vnode_status_specs() ->
 
 get_vnode_status_cmd([_, _ | Args], _, Options) ->
     Nodes = extract_nodes(Options),
-    PerNode = [ {Node, [[{idx, integer_to_binary(Idx)} | tableify(X)] || {Idx, X} <- Res]}
+    PerNode = [{Node, [{integer_to_binary(Idx), jsonify1(X)} || {Idx, X} <- Res]}
                 || {Res, Node} <- vnode_status_on_nodes(Nodes, [])],
     case Args of
         [] ->
@@ -71,34 +70,62 @@ get_vnode_status_cmd([_, _ | Args], _, Options) ->
             clique_status:usage()
     end.
 
-tableify(PP) ->
-    lists:append([tableify1(P) || P <- PP]).
+jsonify1(PP) ->
+    lists:append([jsonify2(P) || P <- PP]).
 
-tableify1({P, undefined}) ->
+jsonify2({P, undefined}) ->
     [{P, null}];
-tableify1({backend_status, Backend, BS}) ->
-    [{backend, Backend}, {backend_status, tableify_backend(Backend, BS)}];
-tableify1({vnodeid, Id}) ->
+jsonify2({backend_status, riak_kv_multi_backend, BB}) ->
+    [{backend, riak_kv_multi_backend},
+     {backend_status, [{N, [{mod, Mod} | jsonify_backend(Mod, Status)]} || {N, [{mod, Mod} | Status]} <- BB]}];
+jsonify2({backend_status, N, BS}) ->
+    [{backend, N}, {backend_status, jsonify_backend(N, BS)}];
+jsonify2({vnodeid, Id}) ->
     [{vnodeid, printable_bin(Id)}];
-tableify1(P) -> [P].
+jsonify2(P) -> [P].
 
-tableify_backend(riak_kv_leveled_backend, PP) ->
-    [tableify_led_prop(P) || P <- PP];
-tableify_backend(_, PP) when is_map(PP) ->
-    maps:to_list(PP);
-tableify_backend(_, PP) ->
-    PP.
+jsonify_backend(Backend, PP) ->
+    lists:append(
+      [jsonify_backend_prop(Backend, P) || P <- PP]).
 
-tableify_led_prop({A, undefined}) ->
-    {A, undefined};
-tableify_led_prop({A, TS}) when A =:= penciller_last_merge_time;
-                                A =:= journal_last_compaction_time ->
-    {A, iolist_to_binary(
-          calendar:system_time_to_rfc3339(TS, [{unit, millisecond}]))};
-tableify_led_prop({penciller_work_backlog_status, {A, B1, B2}}) ->
-    {penciller_work_backlog_status, #{work_items => A, backlog => B1, l0_full => B2}};
-tableify_led_prop(Unchanged) ->
-    Unchanged.
+jsonify_backend_prop(_, {A, undefined}) ->
+    [{A, null}];
+jsonify_backend_prop(riak_kv_leveled_backend, {A, TS})
+  when A =:= penciller_last_merge_time;
+       A =:= journal_last_compaction_time ->
+    [{A, iolist_to_binary(
+           calendar:system_time_to_rfc3339(TS, [{unit, millisecond}]))}];
+jsonify_backend_prop(riak_kv_leveled_backend, {penciller_work_backlog_status, {A, B1, B2}}) ->
+    [{penciller_work_backlog_status, #{work_items => A, backlog => B1, l0_full => B2}}];
+jsonify_backend_prop(riak_kv_leveled_backend, Unchanged) ->
+    [Unchanged];
+
+jsonify_backend_prop(riak_kv_memory_backend, {TableStatus, TSProps})
+  when is_list(TSProps) ->
+    [{TableStatus, any_ref_or_pid_to_string(TSProps, [])}];
+jsonify_backend_prop(riak_kv_eleveldb_backend, {stats, StatsString}) ->
+    case re:run(StatsString,
+                <<"(\\d+) +(\\d+) +(\\d+) +(\\d+) +(\\d+) +(\\d+)">>,
+                [{capture, all, binary}]) of
+        {match, [_|Values]} ->
+            lists:zip(
+              [compactions, level, files_size_mb, time, read_mb, write_mb],
+              [binary_to_integer(X) || X <- Values]);
+        _ ->
+            []
+    end;
+jsonify_backend_prop(_, AsIs) ->
+    [AsIs].
+
+any_ref_or_pid_to_string([], Q) ->
+    Q;
+any_ref_or_pid_to_string([{A, B}|CC], Q) when is_pid(B) ->
+    any_ref_or_pid_to_string(CC, [{A, list_to_binary(pid_to_list(B))} | Q]);
+any_ref_or_pid_to_string([{A, B}|CC], Q) when is_reference(B) ->
+    any_ref_or_pid_to_string(CC, [{A, list_to_binary(ref_to_list(B))} | Q]);
+any_ref_or_pid_to_string([AB|CC], Q) ->
+    any_ref_or_pid_to_string(CC, [AB | Q]).
+
 
 
 vnode_status_on_nodes([], Q) ->

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -61,7 +61,7 @@ get_vnode_status_specs() ->
 
 get_vnode_status_cmd([_, _ | Args], _, Options) ->
     Nodes = extract_nodes(Options),
-    PerNode = [ {Node, [[{idx, Idx} | tableify(X)] || {Idx, X} <- Res]}
+    PerNode = [ {Node, [[{idx, integer_to_binary(Idx)} | tableify(X)] || {Idx, X} <- Res]}
                 || {Res, Node} <- vnode_status_on_nodes(Nodes, [])],
     case Args of
         [] ->

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -50,22 +50,26 @@ main_usage() ->
         {node, [{shortname, "n"},
                 {longname, "node"},
                 {typecast, fun to_node/1}]}).
+-define(PARTITIONOPT, {partition, [{shortname, "p"},
+                                   {longname, "partition"},
+                                   {typecast, fun to_partition/1}]}).
+
 
 get_vnode_status_specs() ->
     [["riak-admin", "vnode-status"],
-     '_', [?NODEOPT],
+     '_', [?NODEOPT, ?PARTITIONOPT],
      fun get_vnode_status_cmd/3
     ].
 
 
 get_vnode_status_cmd([_, _ | Args], _, Options) ->
     Nodes = extract_nodes(Options),
+    Partitions = extract_vnodes(Options),
     PerNode = [{Node, [{integer_to_binary(Idx), jsonify1(X)} || {Idx, X} <- Res]}
-                || {Res, Node} <- vnode_status_on_nodes(Nodes, [])],
+                || {Res, Node} <- vnode_status_on_nodes(Nodes, Partitions, [])],
     case Args of
         [] ->
-            io:format("~s\n", [mochijson2:encode(PerNode)]),
-            [];
+            [clique_status:text(mochijson2:encode(PerNode))];
         _ ->
             clique_status:usage()
     end.
@@ -130,17 +134,22 @@ any_ref_or_pid_to_string([AB|CC], Q) ->
 
 
 
-vnode_status_on_nodes([], Q) ->
+vnode_status_on_nodes([], _, Q) ->
     Q;
-vnode_status_on_nodes([N|Rest], Q) when N == node() ->
-    Preflists = riak_core_vnode_manager:all_index_pid(riak_kv_vnode),
+vnode_status_on_nodes([N|Rest], PP, Q) when N == node() ->
+    Preflists = filter(PP, riak_core_vnode_manager:all_index_pid(riak_kv_vnode)),
     Res = riak_kv_vnode:vnode_status(Preflists),
-    vnode_status_on_nodes(Rest, [{Res, N} | Q]);
-vnode_status_on_nodes([N|Rest], Q) ->
-    Preflists = rpc:call(N, riak_core_vnode_manager, all_index_pid, [riak_kv_vnode]),
+    vnode_status_on_nodes(Rest, PP, [{Res, N} | Q]);
+vnode_status_on_nodes([N|Rest], PP, Q) ->
+    Preflists = filter(PP, rpc:call(N, riak_core_vnode_manager, all_index_pid, [riak_kv_vnode])),
     Res = rpc:call(N, riak_kv_vnode, vnode_status, [Preflists]),
-    vnode_status_on_nodes(Rest, [{Res, N} | Q]).
+    vnode_status_on_nodes(Rest, PP, [{Res, N} | Q]).
 
+filter(all, Preflists) ->
+    Preflists;
+filter(PP, Preflists) ->
+    lists:filter(
+      fun({P, _}) -> lists:member(P, PP) end, Preflists).
 
 extract_nodes(Options) ->
     NN = [N || {node, N} <- Options],
@@ -153,11 +162,28 @@ extract_nodes(Options) ->
             [node()]
     end.
 
+extract_vnodes(Options) ->
+    PP = [P || {partition, P} <- Options],
+    case lists:member(all, PP) or (length(PP) == 0) of
+        true ->
+            all;
+        false ->
+            PP
+    end.
+
 to_node("all") ->
     all;
 to_node(A) ->
     clique_typecast:to_node(A).
 
+to_partition("all") ->
+    all;
+to_partition(A) ->
+    try
+        list_to_integer(A)
+    catch _:_ ->
+            {error, bad_partition}
+    end.
 
 printable_bin(K) ->
     iolist_to_binary(["0x", mochihex:to_hex(K)]).

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -79,6 +79,8 @@ map_from_deep_list(A) when is_map(A) ->
     maps:fold(fun(K, V, Q) -> Q#{K => map_from_deep_list(V)} end, #{}, A);
 map_from_deep_list([{_,_}|_] = A) ->
     lists:foldl(fun({K, V}, Q) -> Q#{K => map_from_deep_list(V)} end, #{}, A);
+map_from_deep_list(A) when is_list(A) ->
+    lists:map(fun map_from_deep_list/1, A);
 map_from_deep_list(A) -> A.
 
 

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -130,6 +130,10 @@ any_ref_or_pid_to_string([AB|CC], Q) ->
 
 vnode_status_on_nodes([], Q) ->
     Q;
+vnode_status_on_nodes([N|Rest], Q) when N == node() ->
+    Preflists = riak_core_vnode_manager:all_index_pid(riak_kv_vnode),
+    Res = riak_kv_vnode:vnode_status(Preflists),
+    vnode_status_on_nodes(Rest, [{Res, N} | Q]);
 vnode_status_on_nodes([N|Rest], Q) ->
     Preflists = rpc:call(N, riak_core_vnode_manager, all_index_pid, [riak_kv_vnode]),
     Res = rpc:call(N, riak_kv_vnode, vnode_status, [Preflists]),

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -75,9 +75,11 @@ jsonify1(PP) ->
 
 jsonify2({P, undefined}) ->
     [{P, null}];
-jsonify2({backend_status, riak_kv_multi_backend, BB}) ->
-    [{backend, riak_kv_multi_backend},
-     {backend_status, [{N, [{mod, Mod} | jsonify_backend(Mod, Status)]} || {N, [{mod, Mod} | Status]} <- BB]}];
+jsonify2({backend_status, MB, BB}) when MB == riak_kv_multi_backend;
+                                        MB == riak_kv_multi_prefix_backend ->
+    [{backend, MB},
+     {backend_status, [{N, [{mod, Mod} | jsonify_backend(Mod, Status)]}
+                       || {N, [{mod, Mod} | Status]} <- BB]}];
 jsonify2({backend_status, N, BS}) ->
     [{backend, N}, {backend_status, jsonify_backend(N, BS)}];
 jsonify2({vnodeid, Id}) ->

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -69,10 +69,18 @@ get_vnode_status_cmd([_, _ | Args], _, Options) ->
                 || {Res, Node} <- vnode_status_on_nodes(Nodes, Partitions, [])],
     case Args of
         [] ->
-            [clique_status:text(mochijson2:encode(PerNode))];
+            [clique_status:text(
+               riak_kv_wm_json:encode(map_from_deep_list(PerNode)))];
         _ ->
             clique_status:usage()
     end.
+
+map_from_deep_list(A) when is_map(A) ->
+    maps:fold(fun(K, V, Q) -> Q#{K => map_from_deep_list(V)} end, #{}, A);
+map_from_deep_list([{_,_}|_] = A) ->
+    lists:foldl(fun({K, V}, Q) -> Q#{K => map_from_deep_list(V)} end, #{}, A);
+map_from_deep_list(A) -> A.
+
 
 jsonify1(PP) ->
     lists:append([jsonify2(P) || P <- PP]).

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -126,7 +126,13 @@ jsonify_backend_prop(riak_kv_eleveldb_backend, {stats, StatsString}) ->
               [compactions, level, files_size_mb, time, read_mb, write_mb],
               [binary_to_integer(X) || X <- Values]);
         _ ->
-            []
+            %% on fresh start, eleveldb (sometimes?) doesn't report these items, so:
+            [{compactions, 0},
+             {level, -1},
+             {files_size_mb, 0},
+             {time, 0},
+             {read_mb, 0},
+             {write_mb, 0}]
     end;
 
 jsonify_backend_prop(riak_kv_bitcask_backend, {status, StatusTuples}) ->

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -1,0 +1,130 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2026 TI Tokyo.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_kv_vnode_status_cli).
+
+-behaviour(clique_handler).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([register_cli/0]).
+-export([vnode_status_on_nodes/2, tableify/1, tableify1/1]).
+
+register_cli() ->
+    register_all_usage(),
+    register_all_commands().
+
+register_all_usage() ->
+    clique:register_usage(["riak-admin", "vnode-status"], main_usage()).
+
+register_all_commands() ->
+    lists:foreach(
+      fun(Args) -> apply(clique, register_command, Args) end,
+      [get_vnode_status_specs()]).
+
+main_usage() ->
+    ["riak-admin vnode-status [-n|--node NODE|all] [-p|--partition PARTITION|all]\n",
+     "Print vnode status, including backend stats and info,\n",
+     "on specified NODE and PARTITION (defaults to current node\n",
+     "and all partitions), as a json object.\n"
+    ].
+
+
+-define(NODEOPT,
+        {node, [{shortname, "n"},
+                {longname, "node"},
+                {typecast, fun to_node/1}]}).
+
+get_vnode_status_specs() ->
+    [["riak-admin", "vnode-status"],
+     '_', [?NODEOPT],
+     fun get_vnode_status_cmd/3
+    ].
+
+
+get_vnode_status_cmd([_, _ | Args], _, Options) ->
+    Nodes = extract_nodes(Options),
+    PerNode = [ {Node, [[{idx, Idx} | tableify(X)] || {Idx, X} <- Res]}
+                || {Res, Node} <- vnode_status_on_nodes(Nodes, [])],
+    case Args of
+        [] ->
+            io:format("~s\n", [mochijson2:encode(PerNode)]),
+            [];
+        _ ->
+            clique_status:usage()
+    end.
+
+tableify(PP) ->
+    lists:append([tableify1(P) || P <- PP]).
+
+tableify1({P, undefined}) ->
+    [{P, null}];
+tableify1({backend_status, Backend, BS}) ->
+    [{backend, Backend}, {backend_status, tableify_backend(Backend, BS)}];
+tableify1({vnodeid, Id}) ->
+    [{vnodeid, printable_bin(Id)}];
+tableify1(P) -> [P].
+
+tableify_backend(riak_kv_leveled_backend, PP) ->
+    [tableify_led_prop(P) || P <- PP];
+tableify_backend(_, PP) when is_map(PP) ->
+    maps:to_list(PP);
+tableify_backend(_, PP) ->
+    PP.
+
+tableify_led_prop({A, undefined}) ->
+    {A, undefined};
+tableify_led_prop({A, TS}) when A =:= penciller_last_merge_time;
+                                A =:= journal_last_compaction_time ->
+    {A, iolist_to_binary(
+          calendar:system_time_to_rfc3339(TS, [{unit, millisecond}]))};
+tableify_led_prop({penciller_work_backlog_status, {A, B1, B2}}) ->
+    {penciller_work_backlog_status, #{work_items => A, backlog => B1, l0_full => B2}};
+tableify_led_prop(Unchanged) ->
+    Unchanged.
+
+
+vnode_status_on_nodes([], Q) ->
+    Q;
+vnode_status_on_nodes([N|Rest], Q) ->
+    Preflists = rpc:call(N, riak_core_vnode_manager, all_index_pid, [riak_kv_vnode]),
+    Res = rpc:call(N, riak_kv_vnode, vnode_status, [Preflists]),
+    vnode_status_on_nodes(Rest, [{Res, N} | Q]).
+
+
+extract_nodes(Options) ->
+    NN = [N || {node, N} <- Options],
+    case lists:member(all, NN) of
+        true ->
+            [node() | nodes()];
+        false when NN /= [] ->
+            NN;
+        _ ->
+            [node()]
+    end.
+
+to_node("all") ->
+    all;
+to_node(A) ->
+    clique_typecast:to_node(A).
+
+
+printable_bin(K) ->
+    iolist_to_binary(["0x", mochihex:to_hex(K)]).

--- a/src/riak_kv_vnode_status_cli.erl
+++ b/src/riak_kv_vnode_status_cli.erl
@@ -120,6 +120,11 @@ jsonify_backend_prop(riak_kv_eleveldb_backend, {stats, StatsString}) ->
         _ ->
             []
     end;
+
+jsonify_backend_prop(riak_kv_bitcask_backend, {status, StatusTuples}) ->
+    [{status, [[{filename, list_to_binary(A1)}, {fragmented, A2},
+                {dead_bytes, A3}, {total_bytes, A4}] || {A1, A2, A3, A4} <- StatusTuples]}];
+
 jsonify_backend_prop(_, AsIs) ->
     [AsIs].
 


### PR DESCRIPTION
`riak admin vnode-status | sed -n 1p | json_pp` will now produce vnode backend status (for leveled, collected by `leveled_bookie:book_status/1`) as a JSON blob, like this:

```
{
   "dev1@127.0.0.1" : [
      {
         "backend" : "riak_kv_leveled_backend",
         "backend_status" : {
            "fetch_count_by_level" : {
               "0" : {
                  "count" : 0,
                  "time" : 0
               }, 
...
            },
            "get_body_time" : 0,
            "get_sample_count" : 0,
            "head_rsp_time" : 0,
            "head_sample_count" : 0,
            "journal_last_compaction_duration" : "undefined",
            "journal_last_compaction_max" : "undefined",
            "journal_last_compaction_mean" : "undefined",
...
            "put_ink_time" : 0,
            "put_mem_time" : 0,
            "put_prep_time" : 0,
            "put_sample_count" : 0
         },
         "counter" : 210000,
         "counter_lease" : 220000,
         "counter_lease_size" : 10000,
         "counter_leasing" : false,
         "idx" : "1210306043414653979137426502093171875652569137152",
         "vnodeid" : "0xe42f1fd9312f8641"
      },
      {
...
```
The command accepts `-n NODE|all` option, to collect and print the status from a specified NODE, or all nodes.

See https://github.com/basho/riak_kv/issues/343.