### PR TITLE
Add `queue_raw_keys` and `queue_raw_terms`

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -147,6 +147,7 @@ repairfun
 foldresult
 jobid
 rtrq
+dataroot
 
 # Riak monitoring terms
 nosync
@@ -390,3 +391,9 @@ subproc
 lz
 edates
 unsync'd
+DmRldjFAMTI
+LjAuMC
+gDdw
+kZXYxQDEyNy
+wLjAuMVh
+xAAAMdwAAAABpPGQWbQAAAARkjfJI

--- a/docs/QueryAPI.md
+++ b/docs/QueryAPI.md
@@ -702,7 +702,7 @@ For queries using an `accumulation_option` of `queue_raw_keys` or `queue_raw_ter
 - `queued_count`; an integer count of results that have been queued so far in response to the query (including any results already returned);
 - `query_complete`; a boolean value which will be `true` when the query has been complete and there will be no more results to be queued.
 
-When the `queued_count` is equal to the `returned_count` and also `query_complete` is true - then there are no more results to be fetched, and all subsequent requests wll contain an empty list of `raw_keys` or `raw_terms`, and unchanged results for `returned_count`, `queued_count` and `query_complete`.
+When the `queued_count` is equal to the `returned_count` and also `query_complete` is true - then there are no more results to be fetched, and all subsequent requests will contain an empty list of `raw_keys` or `raw_terms`, and unchanged results for `returned_count`, `queued_count` and `query_complete`.
 
 e.g.
 

--- a/docs/QueryAPI.md
+++ b/docs/QueryAPI.md
@@ -16,6 +16,8 @@ Through this combination of querying ranges and filtering on projected attribute
 
 The result sets for queries are not limited to returning lists of object keys, there is also support in the Query API for different accumulation options.  As well as returning object keys, accumulation options can be used to efficiently count results, and group both results and counts by specific projected attributes.
 
+Queries are by default synchronous with the full result-set sent directly back to the requesting process on completion of the query.  Queries may be asynchronous, with results queued on-disk (to control memory use) to be consumed in batches by one or more external processes, with results available for consumption prior to the completion of the query.
+
 As well as single queries the API can also handle combination queries.  In combination queries, multiple queries are run as part of the same request and the results of each query are combined using a set operation before results are accumulated to construct the response.  Those set operations are also distributed across the cluster for efficiency; the application of a set operation happens at the scale of the vnode, not the scale of the cluster.  All combination queries are run on a single snapshot per vnode; so the results should always be consistent from the perspective of each potential key in the result set.
 
 For further detail on the Query API:
@@ -469,6 +471,31 @@ In using report-style queries, counting results or grouping counts by a projecte
 
 ## Query - Definition
 
+### API Endpoint - THe URI
+
+All query requests must be sent to the query endpoint for the Bucket (and Bucket Type where typed-buckets are used).
+
+```console
+POST /types/BucketType/buckets/Bucket/query
+```
+
+For legacy (untyped) buckets:
+
+```console
+POST /buckets/Bucket/query
+```
+
+For query requests the `POST` method should be used.
+
+If the accumulation options `queue_raw_keys` or `queue_raw_terms` are used then an opaque reference will be returned as the `result_queue` in the JSON response to the query request.  Results may be fetched from the same URI, using the `GET` method with the reference to the `result_queue` passed as a query parameter.  There is also an optional query parameter `max_results` which puts an upper limit on the number of results sent back in the batch:  For example:
+
+```console
+GET types/BucketType/buckets/Bucket/query?result_queue=g2gDdw5kZXYxQDEyNy4wLjAuMVh3DmRldjFAMTI3LjAuMC4xAAAMdwAAAABpPGQWbQAAAARkjfJI?max_results=1000
+```
+
+{: .note }
+> The `result_queue` reference can be decoded by any node in the cluster.  The result requests for queued batches can be distributed across the cluster.
+
 ### Query JSON - Definition
 
 The query should be posted as the HTTP body, to the query API for the relevant bucket, where there are the following JSON keys at the root of the document
@@ -482,8 +509,10 @@ The query should be posted as the HTTP body, to the query API for the relevant b
 - There are multiple options for accumulating the results from a single query:
   - `keys`; return a list of keys that matched in the query, where the keys have been deduplicated and sorted.
   - `raw_keys`; return a list of keys that matched in the query, but in no specific order and where multiple matches for the same key will result in that key appearing multiple times within the results.
+  - `queue_raw_keys` <span>Available from Riak 3.4.1</span>{: .label .label-purple }; return a reference to a queue, where the results will be streamed to be consumed in batches of keys from any node by one of more external processes.  The results will be as in `raw_keys`, the only difference is the method of returning the results.
   - `terms`; return a list of term/key pairs, ordered by term.
   - `raw_terms`; return a list of term/key pairs, unsorted.
+  - `queue_raw_keys` <span>Available from Riak 3.4.1</span>{: .label .label-purple }; return a reference to a queue, where the results will be streamed to be consumed in batches of term/key pairs from any node by one of more external processes.  The results will be as in `raw_terms`, the only difference is the method of returning the results.
   - `count`; return a count of unique keys that matched the query.
   - `raw_count`; return a count of matches against the query (i.e. unlike `count` if an object key appears against multiple terms matched within the query, with `raw_count` that key will be counted multiple times).
   - `term_with_count`; return a count of unique key matches by term (where term is specified by the `accumulation_term`) in no specific order.
@@ -523,6 +552,14 @@ An array of key/value pairs that are referred to in filter or evaluation express
 The timeout in seconds to wait for the query to complete, before a timeout error is returned.
 
 - This is the timeout used by the server, other HTTP timeouts may exist on the path to Riak, in particular in the Riak client.
+
+#### `inactivity_timeout` (optional)
+
+Relevant only  in `queue_raw_keys` and `queue_raw_terms` queries, where the results are queued on disk to be available for fetch requests.  If no requests are made to fetch from that specific queue within the inactivity timeout (in seconds), the process managing the queue will expire and the disk footprint of the queue will be removed.
+
+There is no API call to close or delete the queue when all the results have been consumed.  Garbage collection is dependent on the inactivity timeout.
+
+The location of the queues on disk is set using the `query_dataroot` option in riak.conf.  Performance of queries with queued result sets may be impacted by the read and write latency to that disk partition, but all reading and writing is batched for efficiency and so the overhead of query queues on disk utilisation should be limited.
 
 #### `query_list` (required)
 
@@ -644,6 +681,33 @@ function ::=
     | begins_with (key, substr)
     | ends_with (key, substr)
     | contains (key, substr)
+```
+
+### Query Responses
+
+The responses to all query requests, including fetches from query result queues, are JSON objects.  For synchronous queries (i.e. requests with an `accumulation_option` other than `queue_raw_keys` or `queue_raw_terms`), the results will be sent under a single JSON key within the JSON object - with that key set to be the `accumulation_option` for the request e.g.
+
+```json
+{ 
+    "keys" : [ "990011234", "990011235" ]
+}
+```
+
+If the `accumulation_option` is `terms` or `raw_keys`, and a `max_results` constraint has been added to the query, then a `continuation` header (`X-Riak-Continuation`) may be added to the response to be used as the `continuation` in a subsequent request (to see the next batch of results).
+
+For queries using an `accumulation_option` of `queue_raw_keys` or `queue_raw_terms` the response is a JSON object containing only a `result_queue` key with its associated value (to be used in subsequent fetch requests).  Fetch requests from the result queue, will return a JSON object with four keys:
+
+- `raw_keys`/`raw_terms`; a batch of results, no bigger than `max_results`.
+- `returned_count`; an integer count of results that have been returned via this API for this query (including the results in this response);
+- `queued_count`; an integer count of results that have been queued so far in response to the query (including any results already returned);
+- `query_complete`; a boolean value which will be `true` when the query has been complete and there will be no more results to be queued.
+
+When the `queued_count` is equal to the `returned_count` and also `query_complete` is true - then there are no more results to be fetched, and all subsequent requests wll contain an empty list of `raw_keys` or `raw_terms`, and unchanged results for `returned_count`, `queued_count` and `query_complete`.
+
+e.g.
+
+```json
+[{<<"query_complete">>,true},{<<"raw_keys">>,[ "990011234", "990011235" ]},{<<"received_count">>,1000},{<<"responses_count">>,0}]
 ```
 
 ## Performance and Efficiency

--- a/priv/riak_kv.schema
+++ b/priv/riak_kv.schema
@@ -82,6 +82,12 @@
   {datatype, directory}
 ]}.
 
+%% @doc A path under which the query result queues will be stored.
+{mapping, "query_dataroot", "riak_kv.query_dataroot", [
+  {default, "$(platform_data_dir)/kv_query"},
+  {datatype, directory}
+]}.
+
 %% @doc The maximum size of the overflow queue for the eraser.  If the queue
 %% goes beyond this point, new additions will be discarded.
 %% To update this at run-time, the configuration item can be changed via

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -39,7 +39,7 @@
 -export([stream_list_buckets/1,stream_list_buckets/2,
          stream_list_buckets/3,stream_list_buckets/4, stream_list_buckets/5]).
 -export([get_index/4,get_index/3]).
--export([query/2]).
+-export([query/2, query_result_request/2]).
 -export([aae_fold/1, aae_fold/2]).
 -export([ttaaefs_fullsync/1, ttaaefs_fullsync/2, ttaaefs_fullsync/3]).
 -export([hotbackup/4]).
@@ -1046,7 +1046,9 @@ hotbackup(BackupPath, DefaultNVal, PlanNVal, {?MODULE, [Node, _ClientId]}) ->
 
 -spec query(
     riak_kv_query:complex_query_definition(), riak_client()) ->
-        {query_result(), none|{{binary(), riak_object:key()}}} |
+        {query_result(), none|
+        {{binary(), riak_object:key()}}} |
+        {result_reference, binary()} |
         {error, timeout} |
         {error, term()}.
 query(Query, {?MODULE, [Node, _ClientId]}) ->
@@ -1056,6 +1058,26 @@ query(Query, {?MODULE, [Node, _ClientId]}) ->
     ?LOG_DEBUG("Query started with worker ~w request ~0p", [Pid, ReqId]),
     wait_for_reqid(ReqId, TimeoutSecs * 1000).
 
+-type result_request_map()
+    ::
+        #{
+            bucket => riak_object:bucket(),
+            encoded_queue_reference => binary(),
+            max_results => non_neg_integer()
+        }.
+
+-spec query_result_request(
+    result_request_map(),
+    riak_client()
+) -> 
+    {ok, riak_kv_query_server:partial_result_map()} |
+    {error, term()}.
+query_result_request(ReqMap, _Client) ->
+    riak_kv_query_filebuffer:return_results(
+        maps:get(encoded_queue_reference, ReqMap),
+        maps:get(max_results, ReqMap),
+        maps:get(bucket, ReqMap)
+    ).
 
 %% @spec get_index(Bucket :: binary(),
 %%                 Query :: riak_index:query_def(),

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -1048,7 +1048,7 @@ hotbackup(BackupPath, DefaultNVal, PlanNVal, {?MODULE, [Node, _ClientId]}) ->
     riak_kv_query:complex_query_definition(), riak_client()) ->
         {query_result(), none|
         {{binary(), riak_object:key()}}} |
-        {result_reference, binary()} |
+        {result_queue, binary()} |
         {error, timeout} |
         {error, term()}.
 query(Query, {?MODULE, [Node, _ClientId]}) ->

--- a/src/riak_kv_overflow_queue.erl
+++ b/src/riak_kv_overflow_queue.erl
@@ -40,6 +40,13 @@
         close/2,
         fetch_batch/3]).
 
+-export(
+    [
+        generate_ordered_guid/0,
+        disklog_filename/2
+    ]
+).
+
 -include_lib("kernel/include/logger.hrl").
 
 -define(QUEUE_LIMIT, 1000).
@@ -399,7 +406,7 @@ generate_ordered_guid() ->
         [Year, Month, Day, H, M, C band 16#0fff, D band 16#3fff bor 16#8000, E]).
 
 
--spec disklog_filename(string(), string()) -> file:filename_all().
+-spec disklog_filename(string(), iolist()) -> file:filename_all().
 disklog_filename(RootPath, GUID) ->
     filename:join(RootPath, GUID ++ ?DISKLOG_EXT).
 

--- a/src/riak_kv_query.erl
+++ b/src/riak_kv_query.erl
@@ -24,13 +24,14 @@
 
 -export(
     [
-        new/3,
+        new/4,
         finalise_request/1,
         get_query_definition/1,
         get_bucket/1,
         get_maxresults/1,
         get_r/1,
         get_timeout_secs/1,
+        get_inactivity_timeout_secs/1,
         get_accumulator/1,
         get_querytype/1,
         get_returnterms/1,
@@ -58,9 +59,9 @@
 -type aggregation_function()
     :: fun((list(sets:set(riak_object:key()))) -> sets:set(riak_object:key())).
 -type smpl_accumulator()
-    :: keys|raw_keys|count|raw_count.
+    :: keys|raw_keys|count|raw_count|queue_raw_keys.
 -type term_accumulator()
-    :: raw_terms|terms|term_with_rawcount|term_with_count.
+    :: raw_terms|terms|term_with_rawcount|term_with_count|queue_raw_terms.
 -type accumulation_option()
     :: smpl_accumulator()|term_accumulator().
 -type query_index_name()
@@ -126,7 +127,7 @@
     {aggregation_function(), list({aggregation_tag(), evaluated_query()})}.
 -type validation_stage() ::
     aggregation_expression|accumulation_option|accumulation_term|
-        max_results|query_evaluation|apply_continuation.
+        max_results|query_evaluation|apply_continuation|init.
 -type validation_error() ::
     {error, validation_stage(), binary()}.
 -type encoding_fun() ::
@@ -139,6 +140,8 @@
         type = single_query
             :: single_query | combo_query,
         timeout_secs
+            :: pos_integer(),
+        inactivity_timeout_secs
             :: pos_integer(),
         aggregation_expression = single_query
             :: single_query|aggregation_function(),
@@ -186,19 +189,24 @@
     ]
 ).
 
--spec new(riak_object:bucket(), query_type(), pos_integer()) -> complex_query_definition().
-new(Bucket, single_query, Timeout) ->
+-spec new(
+    riak_object:bucket(), query_type(), pos_integer(), pos_integer()
+) ->
+    complex_query_definition().
+new(Bucket, single_query, Timeout, InactivityTimeout) ->
     #riak_kv_query{
         bucket = Bucket,
         type = single_query,
         timeout_secs = Timeout,
+        inactivity_timeout_secs = InactivityTimeout,
         aggregation_expression = single_query
     };
-new(Bucket, combo_query, Timeout) ->
+new(Bucket, combo_query, Timeout, InactivityTimeout) ->
     #riak_kv_query{
         bucket = Bucket,
         type = combo_query,
-        timeout_secs = Timeout
+        timeout_secs = Timeout,
+        inactivity_timeout_secs = InactivityTimeout
     }.
 
 -spec finalise_request(
@@ -230,6 +238,10 @@ get_bucket(Query) -> Query#riak_kv_query.bucket.
 -spec get_timeout_secs(complex_query_definition()) -> pos_integer().
 get_timeout_secs(Query) -> Query#riak_kv_query.timeout_secs.
 
+-spec get_inactivity_timeout_secs(complex_query_definition()) -> pos_integer().
+get_inactivity_timeout_secs(Query) ->
+    Query#riak_kv_query.inactivity_timeout_secs.
+
 -spec get_reqid(complex_query_definition()) -> non_neg_integer().
 get_reqid(#riak_kv_query{client_reqid = ReqID}) when ReqID =/= undefined ->
     ReqID.
@@ -257,7 +269,8 @@ get_returnterms(
                 KeyOnly == keys;
                 KeyOnly == raw_keys;
                 KeyOnly == count;
-                KeyOnly == raw_count ->
+                KeyOnly == raw_count;
+                KeyOnly == queue_raw_keys ->
             false;
         _ ->
             case AT of
@@ -321,7 +334,8 @@ add_accumulation_option(
             (
                 AccumulationOption == <<"keys">> orelse
                 AccumulationOption == <<"raw_keys">> orelse
-                AccumulationOption == <<"raw_count">>
+                AccumulationOption == <<"raw_count">> orelse
+                AccumulationOption == <<"queue_raw_keys">>
             ) ->
     {
         ok,
@@ -337,10 +351,12 @@ add_accumulation_option(
             AccumulationOption == <<"raw_keys">>;
             AccumulationOption == <<"count">>;
             AccumulationOption == <<"raw_count">>;
+            AccumulationOption == <<"queue_raw_keys">>;
             AccumulationOption == <<"terms">>;
             AccumulationOption == <<"raw_terms">>;
             AccumulationOption == <<"term_with_rawcount">>;
-            AccumulationOption == <<"term_with_count">> ->
+            AccumulationOption == <<"term_with_count">>;
+            AccumulationOption == <<"queue_raw_terms">> ->
     case Type of
         single_query ->
             {
@@ -637,10 +653,12 @@ decode_option(<<"keys">>) -> keys;
 decode_option(<<"raw_keys">>) -> raw_keys;
 decode_option(<<"count">>) -> count;
 decode_option(<<"raw_count">>) -> raw_count;
+decode_option(<<"queue_raw_keys">>) -> queue_raw_keys;
 decode_option(<<"terms">>) -> terms;
 decode_option(<<"raw_terms">>) -> raw_terms;
 decode_option(<<"term_with_rawcount">>) -> term_with_rawcount;
-decode_option(<<"term_with_count">>) -> term_with_count.
+decode_option(<<"term_with_count">>) -> term_with_count;
+decode_option(<<"queue_raw_terms">>) -> queue_raw_terms.
 
 -spec get_reqid() -> non_neg_integer().
 get_reqid() ->
@@ -657,7 +675,7 @@ is_query(Query) -> is_record(Query, riak_kv_query).
 
 -include_lib("eunit/include/eunit.hrl").
 
-new(Bucket, Type) -> new(Bucket, Type, 60).
+new(Bucket, Type) -> new(Bucket, Type, 60, 120).
 
 bad_aggregation_expression_test() ->
     QS = new({<<"Type">>, <<"Bucket">>}, single_query),

--- a/src/riak_kv_query_buffer.erl
+++ b/src/riak_kv_query_buffer.erl
@@ -79,10 +79,12 @@
         {raw_keys, rawkey_accumulator() } |
         {count, non_neg_integer()} |
         {raw_count, non_neg_integer()} |
+        {queue_raw_keys, rawkey_accumulator()} |
         {terms, term_accumulator()} |
         {raw_terms, rawterm_accumulator()} |
         {term_with_rawcount, countby_aggregator()} |
-        {term_with_count, countby_aggregator()}.
+        {term_with_count, countby_aggregator()} |
+        {queue_raw_terms, rawterm_accumulator()}.
 -type reply_fun()
     :: fun((reply_type()|ping) -> ok).
 
@@ -109,6 +111,8 @@ new(Size, T, ReplyFun) when T == count->
     new_buffer(Size, ReplyFun, raw_keys, #key_agg{}, T);
 new(Size, T, ReplyFun) when T == raw_count ->
     new_buffer(Size, ReplyFun, none, none, T);
+new(Size, T, ReplyFun) when T == queue_raw_keys ->
+    new_buffer(Size, ReplyFun, raw_keys, none, raw_keys);
 new(Size, T, ReplyFun) when T == terms->
     new_buffer(Size, ReplyFun, terms, none, T);
 new(Size, T, ReplyFun) when T == raw_terms->
@@ -116,7 +120,9 @@ new(Size, T, ReplyFun) when T == raw_terms->
 new(Size, T, ReplyFun) when T == term_with_rawcount->
     new_buffer(Size, ReplyFun, terms, #termcount_agg{}, T);
 new(Size, T, ReplyFun) when T == term_with_count ->
-    new_buffer(Size, ReplyFun, terms, #termkeycount_agg{}, T).
+    new_buffer(Size, ReplyFun, terms, #termkeycount_agg{}, T);
+new(Size, T, ReplyFun) when T == queue_raw_terms->
+    new_buffer(Size, ReplyFun, raw_terms, none, raw_terms).
 
 new_buffer({BufferSize, JitterSize}, ReplyFun, AccType, InitAgg, Type)
         when BufferSize >= ?MIN_BUFFER, JitterSize =< BufferSize ->

--- a/src/riak_kv_query_filebuffer.erl
+++ b/src/riak_kv_query_filebuffer.erl
@@ -175,7 +175,11 @@ return_results({Node, Pid, Reference}, MaxResults, B) ->
                     [UnexpectedError]
                 ),
                 {error, unexpected_error}
-    end.
+    end;
+return_results(_UnexpectedRefFormat, _MaxResults, _B) ->
+    ?LOG_WARNING("Queue reference received in unexpected format"),
+    {error, unexpected_error}.
+
 
 -spec query_complete(pid()) -> {ok, non_neg_integer()}.
 query_complete(Pid) ->

--- a/src/riak_kv_query_filebuffer.erl
+++ b/src/riak_kv_query_filebuffer.erl
@@ -91,8 +91,8 @@
     }
 ).
 
--define(RSPCOUNT_KEY, <<"responses_count">>).
--define(RCVCOUNT_KEY, <<"received_count">>).
+-define(RSPCOUNT_KEY, <<"returned_count">>).
+-define(RCVCOUNT_KEY, <<"queued_count">>).
 -define(QCOMPLETE_KEY, <<"query_complete">>).
 
 -type inbound_results() ::

--- a/src/riak_kv_query_filebuffer.erl
+++ b/src/riak_kv_query_filebuffer.erl
@@ -178,7 +178,7 @@ return_results({Node, Pid, Reference}, MaxResults, B) ->
     end;
 return_results(_UnexpectedRefFormat, _MaxResults, _B) ->
     ?LOG_WARNING("Queue reference received in unexpected format"),
-    {error, unexpected_error}.
+    {error, unexpected_reference_format}.
 
 
 -spec query_complete(pid()) -> {ok, non_neg_integer()}.

--- a/src/riak_kv_query_filebuffer.erl
+++ b/src/riak_kv_query_filebuffer.erl
@@ -66,8 +66,8 @@
 
 -export(
     [
-        decode_ref/1,
-        encode_ref/1
+        safe_encode/1,
+        safe_decode/1
     ]
 ). % Required only for riak_test
 
@@ -94,7 +94,6 @@
 -define(RSPCOUNT_KEY, <<"responses_count">>).
 -define(RCVCOUNT_KEY, <<"received_count">>).
 -define(QCOMPLETE_KEY, <<"query_complete">>).
--define(ENCODE_OPTS, #{mode => urlsafe}).
 
 -type inbound_results() ::
     riak_kv_query_server:key_list() | riak_kv_query_server:term_list().
@@ -112,7 +111,7 @@
     {ok, pid(), binary()}.
 new(RootPath, InactivityTimeoutMS, Bucket, AccOpt) ->
     {ok, Pid} =
-        gen_server:start(
+        gen_server:start_link(
             ?MODULE,
             [RootPath, InactivityTimeoutMS, Bucket, AccOpt],
             []
@@ -135,6 +134,7 @@ return_results(RefB, MaxResults, B) when is_binary(RefB), MaxResults >= 0 ->
     return_results(decode_ref(RefB), MaxResults, B);
 return_results({N, Pid, Reference}, MaxResults, B) when N == node() ->
     try
+        true = check_pid(Pid),
         gen_server:call(
             Pid,
             {return_results, MaxResults, Reference, B},
@@ -148,30 +148,33 @@ return_results({N, Pid, Reference}, MaxResults, B) when N == node() ->
         {error, result_server_terminated}
     end;
 return_results({Node, Pid, Reference}, MaxResults, B) ->
-    RemoteResult =
-        erpc:call(
-            Node,
-            riak_kv_query_filebuffer,
-            return_results,
-            [{Node, Pid, Reference}, MaxResults, B]
-        ),
-    case RemoteResult of
-        {ok, Result} when is_map(Result) ->
-            {ok, Result};
-        {error, Term} ->
-            {error, Term};
-        {erpc, noconnection} ->
+    try
+        RemoteResult =
+            erpc:call(
+                Node,
+                riak_kv_query_filebuffer,
+                return_results,
+                [{Node, Pid, Reference}, MaxResults, B]
+            ),
+        case RemoteResult of
+            {ok, Result} when is_map(Result) ->
+                {ok, Result};
+            {error, Term} ->
+                {error, Term}
+        end
+    catch 
+        error:{erpc, ERpcErrorReason} ->
             ?LOG_WARNING(
-                "Issue connecting to query buffer on ~0p from ~0p",
-                [Node, node()]
-            ),
-            {error, node_unreachable};
-        UnexpectedError ->
-            ?LOG_ERROR(
-                "Unexpected error ~0p fetching remote results",
-                [UnexpectedError]
-            ),
-            {error, unexpected_error}
+                    "Error ~0p connecting to query buffer on ~0p from ~0p",
+                    [ERpcErrorReason, Node, node()]
+                ),
+                {error, node_unreachable};
+        _CP:UnexpectedError ->
+                ?LOG_ERROR(
+                    "Unexpected error ~0p fetching remote results",
+                    [UnexpectedError]
+                ),
+                {error, unexpected_error}
     end.
 
 -spec query_complete(pid()) -> {ok, non_neg_integer()}.
@@ -337,13 +340,77 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal Functions
 %%%============================================================================
 
+-ifdef(TEST).
+
+check_pid(Pid) -> is_process_alive(Pid).
+
+-else.
+-spec check_pid(pid()) -> boolean().
+check_pid(Pid) ->
+    is_process_alive(Pid) andalso
+        not
+            ({error, not_found} ==
+                supervisor:get_childspec(
+                    riak_kv_query_filebuffer_sup,
+                    Pid)
+                )
+    .
+
+-endif.
+
 -spec encode_ref(binary()) -> binary().
 encode_ref(Ref) ->
-    base64:encode(term_to_binary({node(), self(), Ref}), ?ENCODE_OPTS).
+    safe_encode(term_to_binary({node(), self(), Ref})).
 
 -spec decode_ref(binary()) -> {node(), pid(), binary()}.
 decode_ref(B64Ref) ->
-    binary_to_term(base64:decode(B64Ref, ?ENCODE_OPTS)).
+    binary_to_term(safe_decode(B64Ref)).
+
+-if(?OTP_RELEASE < 26).
+safe_encode(Bin) ->
+    iolist_to_binary(
+        string:replace(
+            iolist_to_binary(
+                string:replace(
+                    base64:encode(Bin),
+                    "+",
+                    "-",
+                    all
+                )
+            ),
+            "/",
+            "_",
+            all
+        )
+    ).
+
+safe_decode(B64Ref) ->
+    base64:decode(
+        iolist_to_binary(
+            string:replace(
+                iolist_to_binary(
+                    string:replace(
+                        B64Ref,
+                        "-",
+                        "+",
+                        all
+                    )
+                ),
+            "_",
+            "/",
+            all
+            )
+        )
+    ).
+-else.
+-define(ENCODE_OPTS, #{mode => urlsafe}).
+
+safe_encode(Bin) ->
+    base64:encode(Bin, ?ENCODE_OPTS).
+
+safe_decode(B64Ref) ->
+    base64:decode(B64Ref, ?ENCODE_OPTS).
+-endif.
 
 -spec encode_results(
     inbound_results(),
@@ -381,6 +448,17 @@ replenish_buffer(DLog, Buffer, Continuation) ->
 
 -include_lib("eunit/include/eunit.hrl").
 
+unlink_new(RootPath, InactivityTimeoutMS, Bucket, AccOpt) ->
+    {ok, Pid} =
+        gen_server:start(
+            ?MODULE,
+            [RootPath, InactivityTimeoutMS, Bucket, AccOpt],
+            []
+        ),
+    Ref = gen_server:call(Pid, get_ref, infinity),
+    {ok, Pid, Ref}.
+
+
 to_key(N) ->
     list_to_binary(io_lib:format("K~8..0B", [N])).
 
@@ -413,7 +491,7 @@ fetch_all_tester(MaxCount, AccOpt) ->
     RootPath = riak_kv_test_util:get_test_dir("filebuffer_test/"),
     AllKeys = Generator(MaxCount),
     {InitialKeys, RestKeys} = lists:split(MaxCount div 2, AllKeys),
-    {ok, QFB, QFR} = new(RootPath, 2000, Bucket, AccOpt),
+    {ok, QFB, QFR} = unlink_new(RootPath, 2000, Bucket, AccOpt),
     ExpectedInitResult =
         #{
             riak_kv_wm_query:get_result_key(AccOpt) => [],
@@ -477,8 +555,7 @@ fetch_all_tester(MaxCount, AccOpt) ->
         return_results(QFR, BatchSize, Bucket)
     ),
     {ok, Files} = file:list_dir(RootPath),
-    BadRef =
-        base64:encode(term_to_binary({node(), QFB, <<>>}), ?ENCODE_OPTS),
+    BadRef = safe_encode(term_to_binary({node(), QFB, <<>>})),
     ?assertMatch({_N, QFB, <<>>}, decode_ref(BadRef)),
     ?assertMatch(
         {error, incorrect_reference},
@@ -518,5 +595,60 @@ fetch_keys_in_batches(MaxResults, Acc, QFR, Bucket, AccOpt) ->
         {Rsp, Rcv} when Rsp < Rcv ->
             fetch_keys_in_batches(MaxResults, UpdAcc, QFR, Bucket, AccOpt)
     end.
+
+-if(?OTP_RELEASE == 26).
+legacy_encode(Bin) ->
+    iolist_to_binary(
+        string:replace(
+            iolist_to_binary(
+                string:replace(
+                    base64:encode(Bin),
+                    "+",
+                    "-",
+                    all
+                )
+            ),
+            "/",
+            "_",
+            all
+        )
+    ).
+
+legacy_decode(B64Ref) ->
+    base64:decode(
+        iolist_to_binary(
+            string:replace(
+                iolist_to_binary(
+                    string:replace(
+                        B64Ref,
+                        "-",
+                        "+",
+                        all
+                    )
+                ),
+            "_",
+            "/",
+            all
+            )
+        )
+    ).
+
+urlsafe_encode_test() ->
+    RandomNoise =
+        lists:map(
+            fun(I) -> crypto:strong_rand_bytes(I) end,
+            lists:seq(1, 128)
+        ),
+    lists:foreach(
+        fun(Bin) ->
+            LB64 = legacy_encode(Bin),
+            NB64 = safe_encode(Bin),
+            ?assertMatch(Bin, safe_decode(LB64)),
+            ?assertMatch(Bin, legacy_decode(NB64))
+        end,
+        RandomNoise
+    ).
+
+-endif.
 
 -endif.

--- a/src/riak_kv_query_filebuffer.erl
+++ b/src/riak_kv_query_filebuffer.erl
@@ -488,7 +488,7 @@ fetch_all_tester(MaxCount, AccOpt) ->
         end,
     Bucket = {<<"BucketType">>, <<"BucketName">>},
     BatchSize = MaxCount div 20,
-    RootPath = riak_kv_test_util:get_test_dir("filebuffer_test/"),
+    RootPath = riak_core_test_util:get_test_dir("filebuffer_test/"),
     AllKeys = Generator(MaxCount),
     {InitialKeys, RestKeys} = lists:split(MaxCount div 2, AllKeys),
     {ok, QFB, QFR} = unlink_new(RootPath, 2000, Bucket, AccOpt),

--- a/src/riak_kv_query_filebuffer.erl
+++ b/src/riak_kv_query_filebuffer.erl
@@ -209,8 +209,7 @@ init([RootPath, InactivityTimeoutMS, Bucket, AccOpt]) ->
     }.
 
 handle_cast(
-    {aggregate_results, Results}, State)
-        when not State#state.query_complete ->
+    {aggregate_results, Results}, State) ->
     ok = disk_log:alog_terms(State#state.dlog, Results),
     {
         noreply,
@@ -347,13 +346,13 @@ check_pid(Pid) -> is_process_alive(Pid).
 -else.
 -spec check_pid(pid()) -> boolean().
 check_pid(Pid) ->
-    is_process_alive(Pid) andalso
-        not
-            ({error, not_found} ==
-                supervisor:get_childspec(
-                    riak_kv_query_filebuffer_sup,
-                    Pid)
-                )
+    is_process_alive(Pid)
+        andalso
+        ({error, not_found} /=
+            supervisor:get_childspec(
+                riak_kv_query_filebuffer_sup,
+                Pid)
+            )
     .
 
 -endif.

--- a/src/riak_kv_query_filebuffer.erl
+++ b/src/riak_kv_query_filebuffer.erl
@@ -1,0 +1,522 @@
+%% -*- mode: erlang; erlang-indent-level: 4; indent-tabs-mode: nil -*-
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+%% @doc Query buffer for aggregating results on disk.
+%% 
+%% Required for central aggregation and partial fetching of results - unlike
+%% the riak_kv_query_buffer does not do local aggregation, just central
+%% aggregation at the riak_kv_query_server
+%% 
+%% Assumption is that a riak_kv_query_server will pass received results using
+%% aggregate_results/2.  Once all vnodes are complete it will call
+%% query_complete/1.
+%% 
+%% Multiple result receiving process can in parallel call return_results/2.
+%% The result should be returned in the order they were received, in batch
+%% sizes of up to the requested size.  A result should be returned once and
+%% only once.  Result receivers know that there are no more to fetch when
+%% The count of results received is equal to the count of results returned and
+%% also the query_complete flag is true.
+%% 
+%% The reference contains a random secret to protect against a pid() being
+%% reused, and a result receiver pulling results from the wrong buffer. 
+
+-module(riak_kv_query_filebuffer).
+
+-behaviour(gen_server).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export(
+    [
+        new/4,
+        return_results/3,
+        aggregate_results/2,
+        query_complete/1
+    ]
+).
+
+-export(
+    [
+        init/1,
+        handle_call/3,
+        handle_cast/2,
+        handle_info/2,
+        terminate/2,
+        code_change/3,
+        format_status/1
+    ]
+).
+
+-export(
+    [
+        decode_ref/1,
+        encode_ref/1
+    ]
+). % Required only for riak_test
+
+-record(state,
+    {
+        dlog :: term(), % disk_log:log() not exported
+        continuation = start :: disk_log:continuation()|start,
+        buffer = [] :: list()|redacted,
+        rcv_count = 0 :: non_neg_integer(),
+        rsp_count = 0 :: non_neg_integer(),
+        query_complete = false :: boolean(),
+        inactivity_timeout :: pos_integer(),
+        queue_reference :: undefined|binary(),
+        accumulation_option :: raw_keys|raw_terms,
+        bucket :: riak_object:bucket()
+            % The bucket is only required to confirm that query result
+            % request is aligned with the bucket in the query.  Security
+            % requirements may be per-bucket, so prevents an attempt to
+            % read query results from another bucket (guessing the shared
+            % secret)
+    }
+).
+
+-define(RSPCOUNT_KEY, <<"responses_count">>).
+-define(RCVCOUNT_KEY, <<"received_count">>).
+-define(QCOMPLETE_KEY, <<"query_complete">>).
+-define(ENCODE_OPTS, #{mode => urlsafe}).
+
+-type inbound_results() ::
+    riak_kv_query_server:key_list() | riak_kv_query_server:term_list().
+
+%%%============================================================================
+%%% API
+%%%============================================================================
+
+-spec new(
+    file:name_all(),
+    pos_integer(),
+    riak_object:bucket(),
+    riak_kv_query:accumulation_option()
+) -> 
+    {ok, pid(), binary()}.
+new(RootPath, InactivityTimeoutMS, Bucket, AccOpt) ->
+    {ok, Pid} =
+        gen_server:start(
+            ?MODULE,
+            [RootPath, InactivityTimeoutMS, Bucket, AccOpt],
+            []
+        ),
+    Ref = gen_server:call(Pid, get_ref, infinity),
+    {ok, Pid, Ref}.
+
+-spec aggregate_results(pid(), inbound_results()) -> ok.
+aggregate_results(Pid, Results) when is_list(Results) ->
+    gen_server:cast(Pid, {aggregate_results, Results}).
+
+-spec return_results(
+    {node(), pid(), binary()} | binary(),
+    pos_integer(),
+    riak_object:bucket()
+) ->
+    {ok, riak_kv_query_server:partial_result_map()} |
+    {error, term()}.
+return_results(RefB, MaxResults, B) when is_binary(RefB), MaxResults >= 0 ->
+    return_results(decode_ref(RefB), MaxResults, B);
+return_results({N, Pid, Reference}, MaxResults, B) when N == node() ->
+    try
+        gen_server:call(
+            Pid,
+            {return_results, MaxResults, Reference, B},
+            infinity
+        )
+    catch C:EP ->
+        ?LOG_WARNING(
+            "Call to Query FileBuffer failed with ~0p:~0p",
+            [C, EP]
+        ),
+        {error, result_server_terminated}
+    end;
+return_results({Node, Pid, Reference}, MaxResults, B) ->
+    RemoteResult =
+        erpc:call(
+            Node,
+            riak_kv_query_filebuffer,
+            return_results,
+            [{Node, Pid, Reference}, MaxResults, B]
+        ),
+    case RemoteResult of
+        {ok, Result} when is_map(Result) ->
+            {ok, Result};
+        {error, Term} ->
+            {error, Term};
+        {erpc, noconnection} ->
+            ?LOG_WARNING(
+                "Issue connecting to query buffer on ~0p from ~0p",
+                [Node, node()]
+            ),
+            {error, node_unreachable};
+        UnexpectedError ->
+            ?LOG_ERROR(
+                "Unexpected error ~0p fetching remote results",
+                [UnexpectedError]
+            ),
+            {error, unexpected_error}
+    end.
+
+-spec query_complete(pid()) -> {ok, non_neg_integer()}.
+query_complete(Pid) ->
+    gen_server:call(Pid, query_complete, infinity).
+
+
+%%%============================================================================
+%%% gen_server callbacks
+%%%============================================================================
+
+init([RootPath, InactivityTimeoutMS, Bucket, AccOpt]) ->
+    QueueRef = crypto:strong_rand_bytes(4),
+    QueueName = encode_ref(QueueRef),
+    FilePath =
+        riak_kv_overflow_queue:disklog_filename(
+            RootPath,
+            riak_kv_overflow_queue:generate_ordered_guid()
+        ),
+    ok = filelib:ensure_dir(FilePath),
+    {ok, DL} = disk_log:open([{name, QueueName}, {file, FilePath}]),
+    {
+        ok,
+        #state{
+            dlog = DL,
+            inactivity_timeout = InactivityTimeoutMS,
+            queue_reference = QueueRef,
+            accumulation_option = AccOpt,
+            bucket = Bucket
+        },
+        InactivityTimeoutMS
+    }.
+
+handle_cast(
+    {aggregate_results, Results}, State)
+        when not State#state.query_complete ->
+    ok = disk_log:alog_terms(State#state.dlog, Results),
+    {
+        noreply,
+        State#state{rcv_count = State#state.rcv_count + length(Results)},
+        State#state.inactivity_timeout
+    }.
+
+handle_call(get_ref, _From, State) ->
+    case disk_log:info(State#state.dlog)
+        of InfoList when is_list(InfoList) ->
+            {name, Ref} = lists:keyfind(name, 1, InfoList),
+            {
+                reply,
+                Ref,
+                State,
+                State#state.inactivity_timeout
+            }
+    end;
+handle_call(
+    {return_results, _MR, _Ref, OB}, _From, State = #state{bucket = QB})
+        when OB =/= QB ->
+    {
+        reply,
+        {error, incorrect_bucket},
+        State,
+        State#state.inactivity_timeout
+    };
+handle_call(
+    {return_results, _MR, Ref, _OB},
+    _From,
+    State = #state{queue_reference = QR})
+        when Ref =/= QR ->
+    {
+        reply,
+        {error, incorrect_reference},
+        State,
+        State#state.inactivity_timeout
+    };
+handle_call(
+    {return_results, MaxResults, _Ref, _OB}, _From, State = #state{buffer = B})
+        when is_list(B), length(B) >= MaxResults ->
+    {ExtractedResults, UpdBuffer} = lists:split(MaxResults, B),
+    UpdRspCount = State#state.rsp_count + MaxResults,
+    EncodedResults =
+        encode_results(
+            ExtractedResults,
+            UpdRspCount,
+            State#state.rcv_count,
+            State#state.query_complete,
+            State#state.accumulation_option
+        ),
+    {
+        reply,
+        {ok, EncodedResults},
+        State#state{
+            buffer = UpdBuffer,
+            rsp_count = UpdRspCount
+        },
+        State#state.inactivity_timeout
+    };
+handle_call(
+    {return_results, MaxResults, _Ref, _OB}, _From, State = #state{buffer = B})
+        when is_list(B) ->
+    {ExtendedBuffer, UpdContinuation} =
+        replenish_buffer(
+            State#state.dlog,
+            B,
+            State#state.continuation
+        ),
+    ResultCount = min(MaxResults, length(ExtendedBuffer)),
+    UpdRspCount = State#state.rsp_count + ResultCount,
+    {ExtractedResults, UpdBuffer} = lists:split(ResultCount, ExtendedBuffer),
+    EncodedResults =
+        encode_results(
+            ExtractedResults,
+            UpdRspCount,
+            State#state.rcv_count,
+            State#state.query_complete,
+            State#state.accumulation_option
+        ),
+    {
+        reply,
+        {ok, EncodedResults},
+        State#state{
+            buffer = UpdBuffer,
+            rsp_count = UpdRspCount,
+            continuation = UpdContinuation
+        },
+        State#state.inactivity_timeout
+    };
+handle_call(query_complete, _From, State) ->
+    {
+        reply,
+        {ok, State#state.rcv_count},
+        State#state{query_complete = true},
+        State#state.inactivity_timeout
+    }.
+    
+handle_info(timeout, State) ->
+    {stop, normal, State}.
+
+terminate(_Reason, _State = #state{dlog = DLog}) ->
+    case disk_log:info(DLog)
+        of InfoList when is_list(InfoList) ->
+            {file, FN} = lists:keyfind(file, 1, InfoList),
+            ok = disk_log:close(DLog),
+            file:delete(FN)
+    end.
+
+format_status(Status) ->
+    case maps:get(reason, Status, normal) of
+        terminate ->
+            State = maps:get(state, Status),
+            maps:update(
+                state,
+                State#state{buffer = redacted},
+                Status
+            );
+        _ ->
+            Status
+    end.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%============================================================================
+%%% Internal Functions
+%%%============================================================================
+
+-spec encode_ref(binary()) -> binary().
+encode_ref(Ref) ->
+    base64:encode(term_to_binary({node(), self(), Ref}), ?ENCODE_OPTS).
+
+-spec decode_ref(binary()) -> {node(), pid(), binary()}.
+decode_ref(B64Ref) ->
+    binary_to_term(base64:decode(B64Ref, ?ENCODE_OPTS)).
+
+-spec encode_results(
+    inbound_results(),
+    non_neg_integer(),
+    non_neg_integer(),
+    boolean(),
+    riak_kv_query:accumulation_option()
+) ->
+        riak_kv_query_server:partial_result_map().
+encode_results(Results, RspCount, RcvCount, Complete, AccOpt) ->
+    #{
+        riak_kv_wm_query:get_result_key(AccOpt) => Results,
+        ?RSPCOUNT_KEY => RspCount,
+        ?RCVCOUNT_KEY => RcvCount,
+        ?QCOMPLETE_KEY => Complete
+    }.
+
+-spec replenish_buffer(
+    term(), inbound_results(), disk_log:continuation()|start
+) ->
+    {inbound_results(), disk_log:continuation()|start}.
+replenish_buffer(DLog, Buffer, Continuation) ->
+    case disk_log:chunk(DLog, Continuation) of
+        eof ->
+            {Buffer, Continuation};
+        {Continuation2, Terms} ->
+            {Buffer ++ Terms, Continuation2}
+    end.
+
+%%%============================================================================
+%%% Test
+%%%============================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+to_key(N) ->
+    list_to_binary(io_lib:format("K~8..0B", [N])).
+
+to_term(N) ->
+    list_to_binary(io_lib:format("T~8..0B", [N])).
+
+generate_keys(Max) ->
+    lists:map(fun to_key/1, lists:seq(1, Max)).
+
+generate_terms(Max) ->
+    lists:map(fun(N) -> {to_term(N), to_key(N)} end, lists:seq(1, Max)).
+
+fetch_all_test_() ->
+    {timeout, 30, fun fetch_all_tester/0}.
+
+fetch_all_tester() ->
+    fetch_all_tester(100000, raw_keys),
+    fetch_all_tester(60000, raw_terms).
+
+fetch_all_tester(MaxCount, AccOpt) ->
+    Generator =
+        case AccOpt of
+            raw_keys ->
+                fun generate_keys/1;
+            raw_terms ->
+                fun generate_terms/1
+        end,
+    Bucket = {<<"BucketType">>, <<"BucketName">>},
+    BatchSize = MaxCount div 20,
+    RootPath = riak_kv_test_util:get_test_dir("filebuffer_test/"),
+    AllKeys = Generator(MaxCount),
+    {InitialKeys, RestKeys} = lists:split(MaxCount div 2, AllKeys),
+    {ok, QFB, QFR} = new(RootPath, 2000, Bucket, AccOpt),
+    ExpectedInitResult =
+        #{
+            riak_kv_wm_query:get_result_key(AccOpt) => [],
+            ?RSPCOUNT_KEY => 0,
+            ?RCVCOUNT_KEY => 0,
+            ?QCOMPLETE_KEY => false
+        },
+    ?assertMatch(
+        {ok, ExpectedInitResult},
+        return_results(QFR, BatchSize, Bucket)
+    ),
+    ?assertMatch(
+        {error, incorrect_bucket},
+        return_results(QFR, BatchSize, {<<"BucketType">>, <<"ButWrongName">>})
+    ),
+    send_keys_in_batches(BatchSize, InitialKeys, QFB),
+    ExpectedEmptyResult =
+        #{
+            riak_kv_wm_query:get_result_key(AccOpt) => [],
+            ?RSPCOUNT_KEY => 0,
+            ?RCVCOUNT_KEY => MaxCount div 2,
+            ?QCOMPLETE_KEY => false
+        },
+    ?assertMatch({ok, ExpectedEmptyResult}, return_results(QFR, 0, Bucket)),
+    InitialRsp =
+        fetch_keys_in_batches(BatchSize div 2, [], QFR, Bucket, AccOpt),
+    ?assert(MaxCount div 2 == length(InitialRsp)),
+    ?assertMatch(InitialKeys, InitialRsp),
+    ExpectedHWResult =
+        #{
+            riak_kv_wm_query:get_result_key(AccOpt) => [],
+            ?RSPCOUNT_KEY => MaxCount div 2,
+            ?RCVCOUNT_KEY => MaxCount div 2,
+            ?QCOMPLETE_KEY => false
+        },
+    ?assertMatch(
+        {ok, ExpectedHWResult},
+        return_results(QFR, BatchSize, Bucket)
+    ),
+    send_keys_in_batches(BatchSize, RestKeys, QFB),
+    ?assertMatch({ok, MaxCount}, query_complete(QFB)),
+    TotalRsp =
+        fetch_keys_in_batches(
+            BatchSize div 2,
+            lists:reverse(InitialRsp),
+            QFR,
+            Bucket,
+            AccOpt
+        ),
+    ?assert(MaxCount == length(TotalRsp)),
+    ?assertMatch(AllKeys, TotalRsp),
+    ExpectedFinalResult =
+        #{
+            riak_kv_wm_query:get_result_key(AccOpt) => [],
+            ?RSPCOUNT_KEY => MaxCount,
+            ?RCVCOUNT_KEY => MaxCount,
+            ?QCOMPLETE_KEY => true
+        },
+    ?assertMatch(
+        {ok, ExpectedFinalResult},
+        return_results(QFR, BatchSize, Bucket)
+    ),
+    {ok, Files} = file:list_dir(RootPath),
+    BadRef =
+        base64:encode(term_to_binary({node(), QFB, <<>>}), ?ENCODE_OPTS),
+    ?assertMatch({_N, QFB, <<>>}, decode_ref(BadRef)),
+    ?assertMatch(
+        {error, incorrect_reference},
+        return_results(BadRef, BatchSize, Bucket)
+    ),
+    timer:sleep(2000 + 10),
+    ?assertMatch(
+        {error, result_server_terminated},
+        return_results(QFR, BatchSize, Bucket)
+    ),
+    {ok, FilesLessOne} = file:list_dir(RootPath),
+    ?assert(length(Files) - 1 == length(FilesLessOne)).
+
+
+send_keys_in_batches(BatchSize, KeyList, QFB) when length(KeyList) < BatchSize ->
+    aggregate_results(QFB, KeyList);
+send_keys_in_batches(BatchSize, KeyList, QFB) ->
+    {Results, Rest} = lists:split(BatchSize, KeyList),
+    aggregate_results(QFB, Results),
+    send_keys_in_batches(BatchSize, Rest, QFB).
+
+fetch_keys_in_batches(MaxResults, Acc, QFR, Bucket, AccOpt) ->
+    {ok, ResultMap} = return_results(QFR, MaxResults, Bucket),
+    UpdAcc =
+        lists:reverse(
+            maps:get(
+                riak_kv_wm_query:get_result_key(AccOpt),
+                ResultMap
+            )
+        ) ++ Acc,
+    case {
+        maps:get(?RSPCOUNT_KEY, ResultMap),
+        maps:get(?RCVCOUNT_KEY, ResultMap)
+    } of
+        {Rsp, Rcv} when Rsp == Rcv ->
+            lists:reverse(UpdAcc);
+        {Rsp, Rcv} when Rsp < Rcv ->
+            fetch_keys_in_batches(MaxResults, UpdAcc, QFR, Bucket, AccOpt)
+    end.
+
+-endif.

--- a/src/riak_kv_query_filebuffer_sup.erl
+++ b/src/riak_kv_query_filebuffer_sup.erl
@@ -1,0 +1,57 @@
+%% -------------------------------------------------------------------
+%%
+%% riak_kv_query_sup: supervise the riak_kv query servers.
+%%
+%% Copyright (c) 2007-2011 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc supervise the riak_kv query servers used to
+%% process complex secondary index queries.
+
+-module(riak_kv_query_filebuffer_sup).
+
+-behaviour(supervisor).
+
+-export([start_query_filebuffer/2]).
+-export([start_link/0]).
+-export([init/1]).
+
+start_query_filebuffer(Node, Args) ->
+    case supervisor:start_child({?MODULE, Node}, Args) of
+        {ok, Pid, ReqID} ->
+            {ok, Pid, ReqID};
+        Error ->
+            Error
+    end.
+
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    QueryChildSpec =
+        {
+            undefined,
+            {riak_kv_query_filebuffer, new, []},
+            temporary,
+            5000,
+            worker,
+            [riak_kv_query_server]
+        },
+
+    {ok, {{simple_one_for_one, 10, 10}, [QueryChildSpec]}}.

--- a/src/riak_kv_query_filebuffer_sup.erl
+++ b/src/riak_kv_query_filebuffer_sup.erl
@@ -20,8 +20,14 @@
 %%
 %% -------------------------------------------------------------------
 
-%% @doc supervise the riak_kv query servers used to
-%% process complex secondary index queries.
+%% @doc supervise the riak_kv query server filebuffers used to
+%% process queues
+%% 
+%% A supervisor is used for the filebuffer, as it external messages will be
+%% received targeting the specific pid().  If the process has expired, or
+%% the request has been doctored - there is a risk that a random pid() will
+%% receive a message it cannot handle (and crash).  So we must always check
+%% the pid is the right type - by confirming it was started by this supervisor.
 
 -module(riak_kv_query_filebuffer_sup).
 

--- a/src/riak_kv_query_server.erl
+++ b/src/riak_kv_query_server.erl
@@ -210,14 +210,12 @@ init(Query) ->
                     queue_raw_keys ->
                         {ok, RP} =
                             application:get_env(riak_kv, query_dataroot),
-                        InactivityTimeoutSecs =
+                        InactivitySecs =
                             riak_kv_query:get_inactivity_timeout_secs(Query),
                         {ok, RPid, RRef} =
-                            riak_kv_query_filebuffer:new(
-                                RP,
-                                1000 * InactivityTimeoutSecs,
-                                Bucket,
-                                raw_keys
+                            riak_kv_query_filebuffer_sup:start_query_filebuffer(
+                                node(),
+                                [RP, 1000 * InactivitySecs, Bucket, raw_keys]
                             ),
                         From ! {ReqID, {result_reference, RRef}},
                         RPid;
@@ -236,14 +234,12 @@ init(Query) ->
                     queue_raw_terms ->
                         {ok, RP} =
                             application:get_env(riak_kv, query_dataroot),
-                        InactivityTimeoutSecs =
+                        InactivitySecs =
                             riak_kv_query:get_inactivity_timeout_secs(Query),
                         {ok, RPid, RRef} =
-                            riak_kv_query_filebuffer:new(
-                                RP,
-                                1000 * InactivityTimeoutSecs,
-                                Bucket,
-                                raw_terms
+                            riak_kv_query_filebuffer_sup:start_query_filebuffer(
+                                node(),
+                                [RP, 1000 * InactivitySecs, Bucket, raw_terms]
                             ),
                         From ! {ReqID, {result_reference, RRef}},
                         RPid

--- a/src/riak_kv_query_server.erl
+++ b/src/riak_kv_query_server.erl
@@ -100,7 +100,7 @@
         bucket :: riak_object:bucket(),
         vnode_monitor :: vnode_monitor(),
         vnodes_ongoing :: sets:set(vnode_id()),
-        acc :: result_record()|redacted,
+        acc :: result_record()|pid()|redacted,
         max_results = unlimited :: pos_integer()|unlimited,
         result_table = none :: none|ets:table(),
         result_encoding_fun :: riak_kv_query:encoding_fun()|raw
@@ -126,9 +126,12 @@
 -type key_list() :: list({riak_object:key()})|list(riak_object:key()).
 -type term_list() :: list({{binary(), riak_object:key()}}).
 -type count_map() :: #{binary() => non_neg_integer()}|#{}.
+-type partial_result_map() ::
+    #{binary() => key_list()|term_list()|non_neg_integer()|boolean()}.
 
 -type result_record() :: #count_acc{}|#list_acc{}|#map_acc{}.
--type results() :: key_list()|term_list()|count_map()|non_neg_integer().
+-type results() ::
+    key_list()|term_list()|count_map()|non_neg_integer()|partial_result_map().
 
 -type from() :: {atom(), req_id(), pid()}.
 -type req_id() :: non_neg_integer().
@@ -138,7 +141,7 @@
 -type vnode_id() :: non_neg_integer().
 -type vnode_monitor() :: #{vnode_id() => non_neg_integer()}|#{}.
 
--export_type([results/0]).
+-export_type([results/0, key_list/0, term_list/0, partial_result_map/0]).
 
 
 %%%============================================================================
@@ -204,6 +207,20 @@ init(Query) ->
                         #list_acc{};
                     raw_keys ->
                         #list_acc{};
+                    queue_raw_keys ->
+                        {ok, RP} =
+                            application:get_env(riak_kv, query_dataroot),
+                        InactivityTimeoutSecs =
+                            riak_kv_query:get_inactivity_timeout_secs(Query),
+                        {ok, RPid, RRef} =
+                            riak_kv_query_filebuffer:new(
+                                RP,
+                                1000 * InactivityTimeoutSecs,
+                                Bucket,
+                                raw_keys
+                            ),
+                        From ! {ReqID, {result_reference, RRef}},
+                        RPid;
                     terms ->
                         #list_acc{};
                     raw_terms ->
@@ -215,7 +232,21 @@ init(Query) ->
                     term_with_rawcount ->
                         #map_acc{};
                     term_with_count ->
-                        #map_acc{}
+                        #map_acc{};
+                    queue_raw_terms ->
+                        {ok, RP} =
+                            application:get_env(riak_kv, query_dataroot),
+                        InactivityTimeoutSecs =
+                            riak_kv_query:get_inactivity_timeout_secs(Query),
+                        {ok, RPid, RRef} =
+                            riak_kv_query_filebuffer:new(
+                                RP,
+                                1000 * InactivityTimeoutSecs,
+                                Bucket,
+                                raw_terms
+                            ),
+                        From ! {ReqID, {result_reference, RRef}},
+                        RPid
                     end,
             erlang:send_after(TimeoutS * 1000, self(), {timeout, ReqID}),
             {
@@ -381,6 +412,19 @@ handle_info(
     };
 handle_info(
     {{ReqID, Vnode}, {From, _B, {T, Results}}}, 
+    #state{req_id = ReqID, result_table = none, acc = QFB} = State)
+        when is_pid(QFB), T == raw_keys orelse T == raw_terms ->
+    riak_kv_vnode:ack_keys(From),
+    ok = riak_kv_query_filebuffer:aggregate_results(QFB, Results),
+    {
+        noreply,
+        State#state{
+            vnode_monitor =
+                update_monitor(Vnode, State#state.vnode_monitor)
+        }
+    };
+handle_info(
+    {{ReqID, Vnode}, {From, _B, {T, Results}}}, 
     #state{req_id = ReqID, result_table = none} = State)
         when T == raw_keys; T == raw_terms ->
     riak_kv_vnode:ack_keys(From),
@@ -465,12 +509,21 @@ handle_info(
     {{ReqID, Vnode}, done}, #state{req_id = ReqID} = State) ->
     UpdCoverageVnodes = sets:del_element(Vnode, State#state.vnodes_ongoing),
     UpdTimings = update_timings(State#state.timings),
-    case sets:size(UpdCoverageVnodes) of
-        0 ->
+    case {sets:size(UpdCoverageVnodes), State#state.acc} of
+        {0, QFB} when is_pid(QFB) ->
+            {ok, ResultsBuffered} =
+                riak_kv_query_filebuffer:query_complete(QFB),
+            log_timings(
+                UpdTimings,
+                State#state.bucket,
+                ResultsBuffered
+            ),
+            {stop, normal, State};
+        {0, Acc} ->
             Results =
                 case State#state.result_table of
                     none ->
-                        extract_results(State#state.acc);
+                        extract_results(Acc);
                     RT0 ->
                         ets:tab2list(RT0)
                 end,
@@ -496,7 +549,7 @@ handle_info(
             ResultsSent =
                 case State#state.result_table of
                     none ->
-                        extract_count(State#state.acc);
+                        extract_count(Acc);
                     RT1 ->
                         ets:info(RT1, size)
                 end,
@@ -645,14 +698,18 @@ log_timings(Timings, Bucket, ResultCount) ->
 log_timings(_Timings, _Bucket, _ResultCount, false) ->
     ok;
 log_timings(Timings, Bucket, ResultCount, true) ->
-    ?LOG_INFO("Index query on bucket=~p " ++
-                "max_vnodeq=~w min_vnodeq=~w sum_vnodeq=~w count_vnodeq=~w " ++
-                "slow_count_vnodeq=~w fast_count_vnodeq=~w result_count=~w",
-                [Bucket,
-                    Timings#timings.max, Timings#timings.min,
-                    Timings#timings.sum, Timings#timings.count,
-                    Timings#timings.slow_count, Timings#timings.fast_count,
-                    ResultCount]).
+    ?LOG_INFO(
+        "Index query on bucket=~p "
+        "max_vnodeq=~w min_vnodeq=~w sum_vnodeq=~w count_vnodeq=~w "
+        "slow_count_vnodeq=~w fast_count_vnodeq=~w result_count=~w",
+        [
+            Bucket,
+            Timings#timings.max, Timings#timings.min,
+            Timings#timings.sum, Timings#timings.count,
+            Timings#timings.slow_count, Timings#timings.fast_count,
+            ResultCount
+        ]
+    ).
 
 %%%============================================================================
 %%% Test

--- a/src/riak_kv_query_server.erl
+++ b/src/riak_kv_query_server.erl
@@ -217,7 +217,7 @@ init(Query) ->
                                 node(),
                                 [RP, 1000 * InactivitySecs, Bucket, raw_keys]
                             ),
-                        From ! {ReqID, {result_reference, RRef}},
+                        From ! {ReqID, {result_queue, RRef}},
                         RPid;
                     terms ->
                         #list_acc{};
@@ -241,7 +241,7 @@ init(Query) ->
                                 node(),
                                 [RP, 1000 * InactivitySecs, Bucket, raw_terms]
                             ),
-                        From ! {ReqID, {result_reference, RRef}},
+                        From ! {ReqID, {result_queue, RRef}},
                         RPid
                     end,
             erlang:send_after(TimeoutS * 1000, self(), {timeout, ReqID}),

--- a/src/riak_kv_query_server.erl
+++ b/src/riak_kv_query_server.erl
@@ -202,48 +202,12 @@ init(Query) ->
             InitMonitor = maps:from_keys(CoverageVnodes, 0),
             VnodesOngoing = sets:from_list(CoverageVnodes, ?VERSION),
             Acc =
-                case AccType of
-                    keys ->
-                        #list_acc{};
-                    raw_keys ->
-                        #list_acc{};
-                    queue_raw_keys ->
-                        {ok, RP} =
-                            application:get_env(riak_kv, query_dataroot),
-                        InactivitySecs =
-                            riak_kv_query:get_inactivity_timeout_secs(Query),
-                        {ok, RPid, RRef} =
-                            riak_kv_query_filebuffer_sup:start_query_filebuffer(
-                                node(),
-                                [RP, 1000 * InactivitySecs, Bucket, raw_keys]
-                            ),
-                        From ! {ReqID, {result_queue, RRef}},
-                        RPid;
-                    terms ->
-                        #list_acc{};
-                    raw_terms ->
-                        #list_acc{};
-                    raw_count ->
-                        #count_acc{};
-                    count ->
-                        #count_acc{};
-                    term_with_rawcount ->
-                        #map_acc{};
-                    term_with_count ->
-                        #map_acc{};
-                    queue_raw_terms ->
-                        {ok, RP} =
-                            application:get_env(riak_kv, query_dataroot),
-                        InactivitySecs =
-                            riak_kv_query:get_inactivity_timeout_secs(Query),
-                        {ok, RPid, RRef} =
-                            riak_kv_query_filebuffer_sup:start_query_filebuffer(
-                                node(),
-                                [RP, 1000 * InactivitySecs, Bucket, raw_terms]
-                            ),
-                        From ! {ReqID, {result_queue, RRef}},
-                        RPid
-                    end,
+                case init_acc(AccType) of
+                    start_queue ->
+                        start_queue(AccType, Query, Bucket, ReqID, From);
+                    InitAcc ->
+                        InitAcc
+                end,
             erlang:send_after(TimeoutS * 1000, self(), {timeout, ReqID}),
             {
                 ok, 
@@ -604,6 +568,45 @@ code_change(_OldVsn, State, _Extra) ->
 %%%============================================================================
 %%% Internal functions
 %%%============================================================================
+
+-spec init_acc(riak_kv_query:accumulation_option()) -> result_record()|start_queue.
+init_acc(KeysType) when KeysType == keys; KeysType == raw_keys ->
+    #list_acc{};
+init_acc(TermType) when TermType == terms; TermType == raw_terms ->
+    #list_acc{};
+init_acc(CountType) when CountType == count; CountType == raw_count ->
+    #count_acc{};
+init_acc(CountByType)
+        when CountByType == term_with_count; CountByType == term_with_rawcount ->
+    #map_acc{};
+init_acc(QueueType)
+        when QueueType == queue_raw_keys; QueueType == queue_raw_terms ->
+    start_queue.
+
+-spec start_queue(
+    queue_raw_keys|queue_raw_terms,
+    riak_kv_query:complex_query_definition(),
+    riak_object:bucket(),
+    req_id(),
+    pid()
+) -> 
+    pid().
+start_queue(QueueType, Query, Bucket, ReqID, From) ->
+    ConvertedType =
+        case QueueType of
+            queue_raw_keys -> raw_keys;
+            queue_raw_terms -> raw_terms
+        end,
+    {ok, RP} = application:get_env(riak_kv, query_dataroot),
+    InactivitySecs =
+        riak_kv_query:get_inactivity_timeout_secs(Query),
+    {ok, RPid, RRef} =
+        riak_kv_query_filebuffer_sup:start_query_filebuffer(
+            node(),
+            [RP, 1000 * InactivitySecs, Bucket, ConvertedType]
+        ),
+    From ! {ReqID, {result_queue, RRef}},
+    RPid.
 
 -spec update_monitor(vnode_id(), vnode_monitor()) -> vnode_monitor().
 update_monitor(Vnode, VnodeMonitor) ->

--- a/src/riak_kv_sup.erl
+++ b/src/riak_kv_sup.erl
@@ -70,6 +70,12 @@ init([]) ->
             {riak_kv_query_sup, start_link, []},
             permanent, infinity, supervisor, [riak_kv_query_sup]
         },
+    QueryFBSup =
+        {
+            riak_kv_query_filebuffer_sup,
+            {riak_kv_query_filebuffer_sup, start_link, []},
+            permanent, infinity, supervisor, [riak_kv_queryfilebuffer_sup]
+        },
     ClusterAAEFsmSup = {riak_kv_clusteraae_fsm_sup,
                    {riak_kv_clusteraae_fsm_sup, start_link, []},
                    permanent, infinity, supervisor, [riak_kv_clusteraae_fsm_sup]},
@@ -134,6 +140,7 @@ init([]) ->
         KeysFsmSup,
         IndexFsmSup,
         QuerySup,
+        QueryFBSup,
         ClusterAAEFsmSup,
         HotBackupAAEFsmSup,
         [EnsemblesKV || riak_core_sup:ensembles_enabled()],

--- a/src/riak_kv_wm_query.erl
+++ b/src/riak_kv_wm_query.erl
@@ -23,66 +23,58 @@
 %% Available operations:
 %%
 %% ```
-%% POST types/BucketType/buckets/Bucket/query
+%% POST types/<BucketType>/buckets/<Bucket>/query
+%% POST buckets/<Bucket>/query (legacy support for untyped buckets)
 %% ```
 %%
 %% The query should be posted as the HTTP body, where there are the following
 %% JSON keys at the root of the document
+%%
+%% ?AGGREGATION_EXPRESSION
+%% ?ACCUMULATION_OPTION
+%% ?ACCUMULATION_TERM
+%% ?SUBSTITUTIONS
+%% ?TIMEOUT
+%% ?MAX_RESULTS
+%% ?CONTINUATION
+%% ?QUERY_LIST
 %% 
-%% - aggregation_expression (optional)
-%% If multiple queries are to be run, the aggregation expression is used to
-%% inform the database how those results should be combined, using $1, $2 etc
-%% to refer to the numeric aggregation_tag for each query - with the key words
-%% UNION, INTERSECT and SUBTRACT to show how the sets of results are to be
-%% combined.  Parenthesis may be used for clarity.
-%% e.g. ($1 INTERSECT $2) UNION ($3 SUBTRACT $1)
+%% Each query in the query list must be a JSON document supporting the
+%% following keys:
 %% 
-%% - accumulation_option (optional - default = keys)
-%% There are six options for accumulating the results from a single query: 
-%% keys (return a list of keys), term_with_keys (return a list of term/key
-%% tuples), match_count (return a count of the matches made), key_count (return
-%% a count of unique keys matched), term_with_matchcount/term_with_keycount
-%% (return a map of term to either count of matches, or count of unique keys).
-%% If an aggregation_expression is used, only keys, key_count and match_count
-%% can be used.
+%% ?QL_AGGREGATION_TAG
+%% ?QL_INDEX_NAME
+%% ?QL_START_TERM
+%% ?QL_END_TERM
+%% ?QL_REGULAR_EXPRESSION
+%% ?QL_EVALUATION_EXPRESSION
+%% ?QL_FILTER_EXPRESSION
 %% 
-%% - accumulation_term (optional - default = $term)
-%% When using an accumulation option of term_with_keys, term_with_matchcount or
-%% term_with_keycount which term in the evaluated index term should be used.
-%% The default is $term - the whole term.  However a sub-term extracted in the
-%% evaluation expression may be used instead.  
+%% For details on usage see https://openriak.github.io/riak_kv/QueryAPI.html.
 %% 
-%% - result_provision (not yet implemented)
+%% Queries POST'd will return a JSON object with the result format determined
+%% by the ?ACCUMULATION_OPTION passed in the query
 %% 
-%% - max_results (not yet implemented)
+%% ```
+%% GET types/<BucketType>/bucket/<Bucket>/query
+%% GET buckets/<Bucket>/query (legacy support for untyped buckets)
+%% ```
 %% 
-%% - term_rate_kpersec (not yet implemented)
+%% The GET operation is used to extract results queued using a query with the
+%% ?ACCUMULATION_OPTION of `queue_raw_keys` or `queue_raw_terms`
 %% 
-%% - substitutions (optional)
-%% A array of key/value pairs that match string that are referred to in queries
-%% to substitution values that should replace those keys in the query.
-%% e.g. {"low_dob" : "19550301", "high_dob" : "19560630"} can be passed as
-%% substitutions to populate an evaluation of
-%% "$dob" BETWEEN ":low_dob" AND ":high_dob"
+%% Requests support two query parameters:
 %% 
-%% - timeout (optional)
-%% The timeout in seconds to wait for the query to complete
+%% ?result_queue=<EncodedQueueReference>%max_results=<NonNegInteger>
 %% 
-%% - query_list
-%% A list of queries (should be a list of just one query if an
-%% aggregation_expression is not used).
-%% Each query has the following parts:
-%% - aggregation_tag (optional unless an aggregation_expression is used)
-%% - index_name (should be a binary index)
-%% - start_term
-%% - end_term
-%% - regular expression (optional alternative to using evaluation or filter
-%%  expressions)
-%% - evaluation_expression (optional, an expression to extract projected
-%% attributes from the term)
-%% - filter_expression (optional, an expression to filter results based on
-%% those projected attributes)
- 
+%% The result_queue is a mandatory parameter, and is returned as the
+%% ?RSP_RESULT_QUEUE key in the JSON object received from POSTing a query with
+%% a queue-based ?ACCUMULATION_OPTION.
+%% 
+%% Multiple client-side processes may request results from the queue
+%% concurrently, from any connected node within the cluster.  Each result will
+%% be returned once only.
+
 -module(riak_kv_wm_query).
 
 -include_lib("webmachine/include/webmachine.hrl").
@@ -99,17 +91,29 @@
     resource_exists/2,
     process_post/2,
     encode_key/2,
-    encode_key_withterm/2
+    encode_key_withterm/2,
+    content_types_provided/2,
+    return_queued_results/2
 ]).
 
--record(ctx, {
-          client,       %% riak_client() - the store client
-          riak,         %% local | {node(), atom()} - params for riak client
-          bucket_type,  %% Bucket type (from uri)
-          query,        %% The query..
-          security,     %% security context
-          accumulation_option
-         }).
+-export(
+    [
+        get_result_key/1
+    ]
+).
+
+-record(ctx,
+    {
+        client,       %% riak_client() - the store client
+        riak,         %% local | {node(), atom()} - params for riak client
+        bucket_type,  %% Bucket type (from uri)
+        query_request,        %% The query..
+        queue_request,
+        security,
+        method
+    }
+).
+
 -type context() :: #ctx{}.
 -type request_data() :: #wm_reqdata{}.
 
@@ -118,6 +122,7 @@
 -define(ACCUMULATION_TERM, <<"accumulation_term">>).
 -define(SUBSTITUTIONS, <<"substitutions">>).
 -define(TIMEOUT, <<"timeout">>).
+-define(INACTIVITY_TIMEOUT, <<"inactivity_timeout">>).
 -define(MAX_RESULTS, <<"max_results">>).
 -define(CONTINUATION, <<"continuation">>).
 -define(QUERY_LIST, <<"query_list">>).
@@ -138,7 +143,6 @@
 -define(ACCKEY_RAWCOUNT, <<"raw_count">>).
 -define(ACCKEY_TERMRAWCOUNT, <<"term_with_rawcount">>).
 
-
 -define(REQUIRED_KEYS, [?QUERY_LIST]).
 -define(POSSIBLE_KEYS,
     [
@@ -147,6 +151,7 @@
         ?ACCUMULATION_TERM,
         ?SUBSTITUTIONS,
         ?TIMEOUT,
+        ?INACTIVITY_TIMEOUT,
         ?QUERY_LIST,
         ?MAX_RESULTS,
         ?CONTINUATION
@@ -174,12 +179,13 @@
 -define(REQUEST_CLASS, {riak_kv, secondary_index}).
 
 -define(QUERY_TIMEOUT, 60).
+-define(QUEUE_INACTIVITY_TIMEOUT, 120).
+-define(MAX_RESULTS_FROM_QUEUE, 1000).
 
 -define(HEAD_CONTINUATION, "X-Riak-Continuation").
 
 -type query_map() ::
     #{binary() => binary()|non_neg_integer()|list(map())}.
-
 
 -spec init(proplists:proplist()) -> {ok, context()}.
 %% @doc Initialize this resource.
@@ -188,7 +194,6 @@ init(Props) ->
        riak=proplists:get_value(riak, Props),
        bucket_type=proplists:get_value(bucket_type, Props)
       }}.
-
 
 -spec service_available(request_data(), context()) ->
     {boolean(), request_data(), context()}.
@@ -199,13 +204,19 @@ service_available(RD, Ctx0=#ctx{riak=RiakProps}) ->
     ClientID = riak_kv_wm_utils:get_client_id(RD),
     case riak_kv_wm_utils:get_riak_client(RiakProps, ClientID) of
         {ok, C} ->
-            {true, RD, Ctx#ctx { client=C }};
+            {
+                true,
+                RD,
+                Ctx#ctx{client = C, method = wrq:method(RD)}
+            };
         Error ->
-            {false,
-             wrq:set_resp_body(
-               io_lib:format("Unable to connect to Riak: ~p~n", [Error]),
-               wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
-             Ctx}
+            {
+                false,
+                wrq:set_resp_body(
+                    io_lib:format("Unable to connect to Riak: ~p~n", [Error]),
+                    wrq:set_resp_header(?HEAD_CTYPE, "text/plain", RD)),
+                Ctx
+            }
     end.
 
 resource_exists(RD, #ctx{bucket_type=BType}=Ctx) ->
@@ -266,17 +277,13 @@ forbidden(ReqDataIn, #ctx{bucket_type = BT, security = Sec} = Context) ->
 -spec allowed_methods(
     request_data(), context()) -> {list(atom()), request_data(), context()}.
 allowed_methods(RD, Ctx) ->
-    {['POST'], RD, Ctx}.
+    {['POST', 'GET'], RD, Ctx}.
 
 -spec malformed_request(
     request_data(), context()) ->
         {boolean(), request_data(), context()}.
-malformed_request(RD, Ctx) ->
-    Bucket =
-        list_to_binary(
-            riak_kv_wm_utils:maybe_decode_uri(RD, wrq:path_info(bucket, RD)
-        )
-    ),
+malformed_request(RD, Ctx) when Ctx#ctx.method =:= 'POST' ->
+    Bucket = get_bucket(RD),
     BT = riak_kv_wm_utils:maybe_bucket_type(Ctx#ctx.bucket_type, Bucket),
     Body = riak_kv_wm_utils:accept_value("application/json", wrq:req_body(RD)),
     case decode_json_body(Body) of
@@ -286,9 +293,9 @@ malformed_request(RD, Ctx) ->
                     QueryList = maps:get(?QUERY_LIST, QueryMap),
                     case check_querylist(QueryList, false) of
                         ok ->
-                            case make_query(BT, QueryMap) of
+                            case make_query_request(BT, QueryMap) of
                                 {ok, Query} ->
-                                    {false, RD, Ctx#ctx{query = Query}};
+                                    {false, RD, Ctx#ctx{query_request = Query}};
                                 {error, Stage, Reason} ->
                                     {
                                         true,
@@ -307,7 +314,93 @@ malformed_request(RD, Ctx) ->
             end;
         {error, Reason} ->
             {true, return_json_error(Reason, RD), Ctx}
+    end;
+malformed_request(RD, Ctx) when Ctx#ctx.method =:= 'GET' ->
+    Bucket = get_bucket(RD),
+    BT = riak_kv_wm_utils:maybe_bucket_type(Ctx#ctx.bucket_type, Bucket),
+    case wrq:get_qs_value("result_queue", RD) of
+        QueueString when is_list(QueueString) ->
+            case wrq:get_qs_value("max_results", RD) of
+                undefined ->
+                    application:get_env(
+                        riak_kv,
+                        queue_raw_max_results,
+                        ?MAX_RESULTS_FROM_QUEUE
+                    );
+                MaxResultsString ->
+                    try
+                        case list_to_integer(MaxResultsString) of
+                            MR when is_integer(MR), MR >= 0 ->
+                                {
+                                    false,
+                                    RD,
+                                    Ctx#ctx{
+                                        queue_request =
+                                            make_queue_request(
+                                                BT,
+                                                list_to_binary(QueueString),
+                                                MR
+                                            )
+                                    }
+                                }
+                                
+                        end
+                    catch
+                        _CP:_EP ->
+                            {
+                                true,
+                                return_json_error(
+                                    "Invalid max_results parameter",
+                                    RD
+                                ),
+                                Ctx
+                            }
+                    end
+            end;
+        _ ->
+            {
+                true,
+                return_json_error(
+                    "No valid result_queue reference"
+                    "passed as query parameter",
+                    RD
+                ),
+                Ctx
+            }
     end.
+
+-spec content_types_provided(request_data(), context()) ->
+    {[{ContentType::string(), Producer::atom()}], request_data(), context()}.
+%% @doc List the content types available for representing this resource.
+%%      "application/json" is the content-type for bucket lists.
+content_types_provided(RD, Ctx) when Ctx#ctx.method =:= 'POST' ->
+    {[{"application/json", nop}], RD, Ctx};
+content_types_provided(RD, Ctx) when Ctx#ctx.method =:= 'GET' ->
+    {[{"application/json", return_queued_results}], RD, Ctx}.
+
+-spec return_queued_results(
+    request_data(), context()
+) -> 
+    {binary(), request_data(), context()}.
+return_queued_results(RD, Ctx = #ctx{queue_request = QR, client = C}) ->
+    case riak_client:query_result_request(QR, C) of
+        {ok, ResultMap} ->
+            {encode_queued_results(ResultMap), RD, Ctx};
+        {error, Reason} ->
+            {{error, Reason}, RD, Ctx}
+    end.
+
+%% The bucket is available in the dispatch properties, however it may need to
+%% URL quoted, and so it needs to be unquoted.
+%% 
+%% Note that it is possible to disable quoting, and force it per request using
+%% the "X-Riak-URL-Encoding" header - hence why the full RD is required to
+%% decide on the unquoting or not of one part.
+get_bucket(RD) ->
+    list_to_binary(
+            riak_kv_wm_utils:maybe_decode_uri(RD, wrq:path_info(bucket, RD)
+        )
+    ).
 
 expand_query_reason(Stage, Reason) ->
     lists:flatten(
@@ -403,25 +496,37 @@ check_keys(Keys, RequiredKeys, PossibleKeys) ->
             }
     end.
 
--spec make_query(
+-spec make_queue_request(
+    riak_object:bucket(), binary(), non_neg_integer()
+) ->
+    #{atom() => term()}.
+make_queue_request(Bucket, EncodedQueueRef, MaxResults) ->
+    #{
+        bucket => Bucket,
+        encoded_queue_reference => EncodedQueueRef,
+        max_results => MaxResults
+    }.
+
+-spec make_query_request(
     riak_object:bucket(), query_map()) ->
         {ok, riak_kv_query:complex_query_definition()}|riak_kv_query:validation_error().
-make_query(BucketType, QueryMap) ->
-    Timeout =
-        maps:get(
-            ?TIMEOUT,
-            QueryMap,
-            application:get_env(riak_kv, query_timeout_secs, ?QUERY_TIMEOUT)
-        ),
-    case Timeout of
-        T when is_integer(T), T > 0 ->
-            InitQuery =
+make_query_request(BucketType, QueryMap) ->
+    case fetch_timeouts(QueryMap) of
+        {ok, Timeout, InactivityTimeout} ->
+            QueryType =
                 case maps:get(?QUERY_LIST, QueryMap) of
                     QueryList when length(QueryList) == 1 ->
-                        riak_kv_query:new(BucketType, single_query, Timeout);
+                        single_query;
                     QueryList when length(QueryList) > 1 ->
-                        riak_kv_query:new(BucketType, combo_query, Timeout)
+                        combo_query
                 end,
+            InitQuery =
+                riak_kv_query:new(
+                    BucketType,
+                    QueryType,
+                    Timeout,
+                    InactivityTimeout
+                ),
             case add_accumulation(QueryMap, InitQuery) of
                 {ok, Q1} ->
                     case add_queries(QueryMap, Q1, QueryList) of
@@ -438,10 +543,43 @@ make_query(BucketType, QueryMap) ->
                 Error ->
                     Error
             end;
+        Error ->
+            Error
+    end.
+
+-spec fetch_timeouts(
+    query_map()
+) ->
+    {ok, pos_integer(), pos_integer()} | riak_kv_query:validation_error().
+fetch_timeouts(QueryMap) ->
+    Timeout =
+        maps:get(
+            ?TIMEOUT,
+            QueryMap,
+            application:get_env(riak_kv, query_timeout_secs, ?QUERY_TIMEOUT)
+        ),
+    InactivityTimeout =
+        maps:get(
+            ?INACTIVITY_TIMEOUT,
+            QueryMap,
+            application:get_env(
+                riak_kv,
+                queue_inactivity_timeout_secs,
+                ?QUEUE_INACTIVITY_TIMEOUT
+            )
+        ),
+    case Timeout of
+        T when is_integer(T), T > 0 ->
+            case InactivityTimeout of
+                IT when is_integer(IT), IT > 0 ->
+                    {ok, T, IT};
+                _ ->
+                    {error, init, <<"Bad inactivity timeout">>}
+            end;
         _ ->
             {error, init, <<"Bad timeout">>}
     end.
-                    
+
 -spec add_accumulation(
     query_map(), riak_kv_query:complex_query_definition())
         -> 
@@ -507,10 +645,10 @@ convert_query(QM) ->
 %% @doc Produce the JSON response to an index lookup.
 process_post(RD, Ctx) ->
     Client = Ctx#ctx.client,
-    AccOpt = riak_kv_query:get_accumulator(Ctx#ctx.query),
+    AccOpt = riak_kv_query:get_accumulator(Ctx#ctx.query_request),
     {ok, Query} =
         riak_kv_query:add_result_encodingfun(
-            Ctx#ctx.query,
+            Ctx#ctx.query_request,
             encoding_function(AccOpt)
         ),
     case riak_client:query(Query, Client) of
@@ -525,6 +663,17 @@ process_post(RD, Ctx) ->
                     )
                 ),
             {{halt, 500}, return_json_error(Error, RD), Ctx};
+        {result_reference, ResultReference} when is_binary(ResultReference) ->
+            {
+                true,
+                wrq:append_to_resp_body(
+                    riak_kv_wm_json:encode(
+                        #{result_reference => ResultReference}
+                    ),
+                    wrq:set_resp_header(?HEAD_CTYPE, "application/json", RD)
+                ),
+                Ctx
+            };
         {JsonEncodedResults, none} when is_binary(JsonEncodedResults) ->
             {
                 true,
@@ -563,51 +712,53 @@ process_post(RD, Ctx) ->
 encoding_function(AccOpt) ->
     fun(Results) -> encode_results(AccOpt, Results) end.
 
+-spec encode_queued_results(
+    riak_kv_query_server:partial_result_map()) -> binary().
+encode_queued_results(ResultMap) ->
+    case maps:is_key(get_result_key(raw_keys), ResultMap) of
+        true ->
+            iolist_to_binary(
+                riak_kv_wm_json:encode(
+                    ResultMap,
+                    fun riak_kv_wm_query:encode_key/2
+                )
+            );
+        false ->
+            case maps:is_key(get_result_key(raw_terms), ResultMap) of
+                true ->
+                    iolist_to_binary(
+                        riak_kv_wm_json:encode(
+                            ResultMap,
+                            fun riak_kv_wm_query:encode_key_withterm/2
+                        )
+                    )
+            end
+    end.
+
 -spec encode_results(
     riak_kv_query:accumulation_option(), riak_kv_query_server:results()) -> binary().
-encode_results(keys, Results) ->
+encode_results(AccOpt, Results) when AccOpt == keys; AccOpt == raw_keys ->
     iolist_to_binary(
         riak_kv_wm_json:encode(
-            #{?ACCKEY_KEYS => Results},
+            #{get_result_key(AccOpt) => Results},
             fun riak_kv_wm_query:encode_key/2
         )
     );
-encode_results(raw_keys, Results) ->
+encode_results(AccOpt, Results) when AccOpt == terms; AccOpt == raw_terms ->
     iolist_to_binary(
         riak_kv_wm_json:encode(
-            #{?ACCKEY_RAWKEYS => Results},
-            fun riak_kv_wm_query:encode_key/2
-        )
-    );
-encode_results(terms, Results) ->
-    iolist_to_binary(
-        riak_kv_wm_json:encode(
-            #{?ACCKEY_TERMS => Results},
+            #{get_result_key(AccOpt) => Results},
             fun riak_kv_wm_query:encode_key_withterm/2
         )
     );
-encode_results(raw_terms, Results) ->
+encode_results(AccOpt, Count) when AccOpt == count; AccOpt == raw_count ->
     iolist_to_binary(
-        riak_kv_wm_json:encode(
-            #{?ACCKEY_RAWTERMS => Results},
-            fun riak_kv_wm_query:encode_key_withterm/2
-        )
+        riak_kv_wm_json:encode(#{get_result_key(AccOpt) => Count})
     );
-encode_results(raw_count, Count) ->
+encode_results(AccOpt, CountMap)
+        when AccOpt == term_with_count; AccOpt == term_with_rawcount ->
     iolist_to_binary(
-        riak_kv_wm_json:encode(#{?ACCKEY_RAWCOUNT => Count})
-    );
-encode_results(count, Count) ->
-    iolist_to_binary(
-        riak_kv_wm_json:encode(#{?ACCKEY_COUNT => Count})
-    );
-encode_results(term_with_rawcount, CountMap) ->
-    iolist_to_binary(
-        riak_kv_wm_json:encode(#{?ACCKEY_TERMRAWCOUNT => CountMap})
-    );
-encode_results(term_with_count, CountMap) ->
-    iolist_to_binary(
-        riak_kv_wm_json:encode(#{?ACCKEY_TERMCOUNT => CountMap})
+        riak_kv_wm_json:encode(#{get_result_key(AccOpt) => CountMap})
     ).
 
 encode_key({{_Term, Key}}, Encode) when is_binary(Key) ->
@@ -623,6 +774,18 @@ encode_key_withterm({Term, Key}, Encode) when is_binary(Term), is_binary(Key) ->
     [123, [Encode(Term, Encode), $: | Encode(Key, Encode)], 125];
 encode_key_withterm(Result, Encode) ->
     riak_kv_wm_json:encode_value(Result, Encode).
+
+-spec get_result_key(riak_kv_query:accumulation_option()) -> binary().
+get_result_key(keys) -> ?ACCKEY_KEYS;
+get_result_key(raw_keys) -> ?ACCKEY_RAWKEYS;
+get_result_key(terms) -> ?ACCKEY_TERMS;
+get_result_key(raw_terms) -> ?ACCKEY_RAWTERMS;
+get_result_key(count) -> ?ACCKEY_COUNT;
+get_result_key(raw_count) -> ?ACCKEY_RAWCOUNT;
+get_result_key(term_with_count) -> ?ACCKEY_TERMCOUNT;
+get_result_key(term_with_rawcount) -> ?ACCKEY_TERMRAWCOUNT.
+
+
 
 %% ===================================================================
 %% EUnit tests
@@ -671,7 +834,7 @@ simple_query_test() ->
             }
         ">>,
     {ok, M} = decode_json_body(SimpleQueryJson),
-    {ok, Q} = make_query({<<"BT">>, <<"B">>}, M),
+    {ok, Q} = make_query_request({<<"BT">>, <<"B">>}, M),
     ?assert(riak_kv_query:is_query(Q)).
 
 invalid_query_ae1_test() ->
@@ -691,7 +854,7 @@ invalid_query_ae1_test() ->
             }
         ">>,
     {ok, M} = decode_json_body(IQJson),
-    {error, S, _E} = make_query({<<"BT">>, <<"B">>}, M),
+    {error, S, _E} = make_query_request({<<"BT">>, <<"B">>}, M),
     ?assertMatch(aggregation_expression, S).
 
 invalid_query_ae2_test() ->
@@ -718,7 +881,7 @@ invalid_query_ae2_test() ->
             }
         ">>,
     {ok, M} = decode_json_body(IQJson),
-    {error, S, _E} = make_query({<<"BT">>, <<"B">>}, M),
+    {error, S, _E} = make_query_request({<<"BT">>, <<"B">>}, M),
     ?assertMatch(aggregation_expression, S).
 
 invalid_query_ae3_test() ->
@@ -745,7 +908,7 @@ invalid_query_ae3_test() ->
             }
         ">>,
     {ok, M} = decode_json_body(IQJson),
-    {error, S, E} = make_query({<<"BT">>, <<"B">>}, M),
+    {error, S, E} = make_query_request({<<"BT">>, <<"B">>}, M),
     ?assertMatch(query_evaluation, S),
     ?assertMatch(<<"Untagged query in combination request">>, E).
 
@@ -755,6 +918,7 @@ valid_query_ae4_test() ->
             {
                 \"aggregation_expression\" : \"$1 INTERSECT $2\",
                 \"timeout\" : 60,
+                \"inactivity_timeout\" : 180,
                 \"query_list\" :
                     [
                         {
@@ -774,7 +938,7 @@ valid_query_ae4_test() ->
             }
         ">>,
     {ok, M} = decode_json_body(IQJson),
-    {ok, Q} = make_query({<<"BT">>, <<"B">>}, M),
+    {ok, Q} = make_query_request({<<"BT">>, <<"B">>}, M),
     ?assert(riak_kv_query:is_query(Q)),
     QueryList = maps:get(<<"query_list">>, M),
     ?assertMatch(ok, check_querylist(QueryList, false)).
@@ -810,7 +974,7 @@ valid_query_ae5_test() ->
             }
         ">>,
     {ok, M} = decode_json_body(IQJson),
-    {ok, Q} = make_query({<<"BT">>, <<"B">>}, M),
+    {ok, Q} = make_query_request({<<"BT">>, <<"B">>}, M),
     ?assert(riak_kv_query:is_query(Q)),
     QueryList = maps:get(<<"query_list">>, M),
     ?assertMatch(ok, check_querylist(QueryList, false)).
@@ -848,7 +1012,7 @@ invalid_query_ae6_test() ->
     {ok, M} = decode_json_body(IQJson),
     ?assertMatch(
         {error, query_evaluation, <<"Invalid eval function">>},
-        make_query({<<"BT">>, <<"B">>}, M)
+        make_query_request({<<"BT">>, <<"B">>}, M)
     ).
 
 invalid_query_ae7_test() ->
@@ -884,7 +1048,7 @@ invalid_query_ae7_test() ->
     {ok, M} = decode_json_body(IQJson),
     ?assertMatch(
         {error, query_evaluation, <<"Invalid filter function">>},
-        make_query({<<"BT">>, <<"B">>}, M)
+        make_query_request({<<"BT">>, <<"B">>}, M)
     ).
 
 invalid_query_ae8_test() ->
@@ -920,7 +1084,7 @@ invalid_query_ae8_test() ->
     {ok, M} = decode_json_body(IQJson),
     ?assertMatch(
         {error, query_evaluation, <<"Invalid filter function">>},
-        make_query({<<"BT">>, <<"B">>}, M)
+        make_query_request({<<"BT">>, <<"B">>}, M)
     ).
 
 invalid_query_to_test() ->
@@ -948,7 +1112,7 @@ invalid_query_to_test() ->
             }
         ">>,
     {ok, M} = decode_json_body(IQJson),
-    {error, S, E} = make_query({<<"BT">>, <<"B">>}, M),
+    {error, S, E} = make_query_request({<<"BT">>, <<"B">>}, M),
     ?assertMatch(init, S),
     ?assertMatch(<<"Bad timeout">>, E).
 

--- a/src/riak_kv_wm_query.erl
+++ b/src/riak_kv_wm_query.erl
@@ -663,12 +663,12 @@ process_post(RD, Ctx) ->
                     )
                 ),
             {{halt, 500}, return_json_error(Error, RD), Ctx};
-        {result_reference, ResultReference} when is_binary(ResultReference) ->
+        {result_queue, ResultReference} when is_binary(ResultReference) ->
             {
                 true,
                 wrq:append_to_resp_body(
                     riak_kv_wm_json:encode(
-                        #{result_reference => ResultReference}
+                        #{result_queue => ResultReference}
                     ),
                     wrq:set_resp_header(?HEAD_CTYPE, "application/json", RD)
                 ),

--- a/src/riak_kv_wm_query.erl
+++ b/src/riak_kv_wm_query.erl
@@ -386,6 +386,20 @@ return_queued_results(RD, Ctx = #ctx{queue_request = QR, client = C}) ->
     case riak_client:query_result_request(QR, C) of
         {ok, ResultMap} ->
             {encode_queued_results(ResultMap), RD, Ctx};
+        {error, result_server_terminated} ->
+            {
+                {halt, 410},
+                    % Response code for Gone, and likely to be permanent.
+                    % This may be as a result of an error on the server, but
+                    % is probably as a result of an error on the client - and
+                    % so to help with load-balancers tracking server errors,
+                    % err on the side of blaming the client
+                return_json_error(
+                    "queue no longer present or not currently reachable\n",
+                    RD
+                ),
+                Ctx
+            };
         {error, Reason} ->
             {{error, Reason}, RD, Ctx}
     end.

--- a/src/riak_kv_wm_query.erl
+++ b/src/riak_kv_wm_query.erl
@@ -400,6 +400,15 @@ return_queued_results(RD, Ctx = #ctx{queue_request = QR, client = C}) ->
                 ),
                 Ctx
             };
+        {error, unexpected_reference_format} ->
+            {
+                {halt, 400},
+                return_json_error(
+                    "queue reference passed had an invalid format\n",
+                    RD
+                ),
+                Ctx
+            };
         {error, Reason} ->
             {{error, Reason}, RD, Ctx}
     end.


### PR DESCRIPTION
It may be possible to require a large `raw_keys` or `raw_terms` query that may require excessive amounts of memory to accumulate.

In this case, the results can now be queued (on disk), and the fetched in batches from the queue (potentially by multiple processes).

This requires two new accumulation_options `queue_raw_keys`/`queue_raw_terms`.  The Queue HTTP API now supports a `GET` as well as a `POST` so that results can be fetched, (async via `GET` following a `POST`).