### PR TITLE
Add non-standard option to replicate repaired tombs

### DIFF
--- a/src/riak_kv_get_fsm.erl
+++ b/src/riak_kv_get_fsm.erl
@@ -349,6 +349,12 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
             NFOk0 = get_option(notfound_ok, Options, default),
             NotFoundOk = riak_kv_util:expand_value(notfound_ok, NFOk0, BucketProps),
             DeletedVClock = get_option(deletedvclock, Options, false),
+            ReturnTombstone =
+                get_option(
+                    return_tombstone,
+                    Options,
+                    StateData#state.return_tombstone
+                ),
             ReturnBody = get_option(return_body, Options, true),
             GetCore =
                 riak_kv_get_core:init(
@@ -359,9 +365,15 @@ validate(timeout, StateData=#state{from = {raw, ReqId, _Pid}, options = Options,
                     NodeConfirms,
                     ReturnBody
                 ),
-            new_state_timeout(execute, StateData#state{get_core = GetCore,
-                                                       timeout = Timeout,
-                                                       req_id = ReqId});
+            new_state_timeout(
+                execute,
+                StateData#state{
+                    get_core = GetCore,
+                    timeout = Timeout,
+                    req_id = ReqId,
+                    return_tombstone = ReturnTombstone
+                }
+            );
         Error ->
             StateData2 = client_reply(Error, StateData),
             {stop, normal, StateData2}

--- a/src/riak_kv_reader.erl
+++ b/src/riak_kv_reader.erl
@@ -134,7 +134,8 @@ action({B, K}, _Redo) ->
                     Opts =
                         [
                             {r, all},
-                            {deletedvclock, true}
+                            {deletedvclock, true},
+                            {return_tombstone, true}
                         ],
                     GetResult = riak_client:get(B, K, Opts, C),
                     maybe_repl({B, K}, GetResult);
@@ -155,9 +156,9 @@ redo() -> true.
 -type get_result() :: {ok, riak_object:riak_object()}|{error, term()}.
 
 -spec maybe_repl(read_reference(), get_result()) -> ok.
-maybe_repl({B, K}, {error, {deleted, TombClock}}) ->
+maybe_repl({B, K}, {ok, {deleted, TombClock, TombStone}}) ->
     riak_kv_stat:update(replicated_repairs),
-    riak_kv_replrtq_src:replrtq_coordput({B, K, TombClock, to_fetch});
+    riak_kv_replrtq_src:replrtq_coordput({B, K, TombClock, {tomb, TombStone}});
 maybe_repl(_, {ok, _RObj}) ->
     ok;
 maybe_repl(_, UnexpectedResult) ->

--- a/src/riak_kv_reader.erl
+++ b/src/riak_kv_reader.erl
@@ -127,9 +127,37 @@ action({B, K}, _Redo) ->
         true ->
             _ = riak_kv_exchange_fsm:repair_consistent({B, K});
         false ->
-            _ = riak_client:get(B, K, C)
+            riak_kv_stat:update(prompted_repairs),
+            case application:get_env(riak_kv, replicate_repair_tomb, false) of
+                true ->
+                    GetResult = riak_client:get(B, K, [{r, all}], C),
+                    maybe_repl({B, K}, GetResult);
+                false ->
+                    _ = riak_client:get(B, K, C),
+                    ok
+            end
     end,
     true.
 
 -spec redo() -> boolean().
 redo() -> true.
+
+%%%============================================================================
+%%% Internal Functions
+%%%============================================================================
+
+-type get_result() :: {ok, riak_object:riak_object()}|{error, term()}.
+
+-spec maybe_repl(read_reference(), get_result()) -> ok.
+maybe_repl({B, K}, {ok, RObj}) ->
+    case riak_kv_util:is_x_deleted(RObj) of
+        true ->
+            riak_kv_stat:update(replicated_repairs),
+            riak_kv_replrtq_src:replrtq_coordput(
+                {B, K, riak_object:vclock(RObj), {tomb, RObj}}
+            );
+        false ->
+            ok
+    end;
+maybe_repl(_, _) ->
+    ok.

--- a/src/riak_kv_reader.erl
+++ b/src/riak_kv_reader.erl
@@ -21,8 +21,9 @@
 %% @doc Queue any read request originating from this node.  This is intended
 %% for background read requests to trigger read repair. 
 
-
 -module(riak_kv_reader).
+-include_lib("kernel/include/logger.hrl").
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -export([start_link/1]).
@@ -130,7 +131,12 @@ action({B, K}, _Redo) ->
             riak_kv_stat:update(prompted_repairs),
             case application:get_env(riak_kv, replicate_repair_tomb, false) of
                 true ->
-                    GetResult = riak_client:get(B, K, [{r, all}], C),
+                    Opts =
+                        [
+                            {r, all},
+                            {deletedvclock, true}
+                        ],
+                    GetResult = riak_client:get(B, K, Opts, C),
                     maybe_repl({B, K}, GetResult);
                 false ->
                     _ = riak_client:get(B, K, C),
@@ -149,15 +155,11 @@ redo() -> true.
 -type get_result() :: {ok, riak_object:riak_object()}|{error, term()}.
 
 -spec maybe_repl(read_reference(), get_result()) -> ok.
-maybe_repl({B, K}, {ok, RObj}) ->
-    case riak_kv_util:is_x_deleted(RObj) of
-        true ->
-            riak_kv_stat:update(replicated_repairs),
-            riak_kv_replrtq_src:replrtq_coordput(
-                {B, K, riak_object:vclock(RObj), {tomb, RObj}}
-            );
-        false ->
-            ok
-    end;
-maybe_repl(_, _) ->
+maybe_repl({B, K}, {error, {deleted, TombClock}}) ->
+    riak_kv_stat:update(replicated_repairs),
+    riak_kv_replrtq_src:replrtq_coordput({B, K, TombClock, to_fetch});
+maybe_repl(_, {ok, _RObj}) ->
+    ok;
+maybe_repl(_, UnexpectedResult) ->
+    ?LOG_INFO("Fetch of prompted repair returned ~0p", [UnexpectedResult]),
     ok.

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -307,7 +307,7 @@ do_update({read_repairs, Preflist}) ->
 do_update(prompted_repairs) ->
     ok = exometer:update([?PFX, ?APP, node, gets, prompted_repairs], 1);
 do_update(replicated_repairs) ->
-    ok = exometer:update([?PFX, ?APP, node, dets, replicated_repairs], 1);
+    ok = exometer:update([?PFX, ?APP, node, gets, replicated_repairs], 1);
 do_update({tictac_aae, ExchangeState}) ->
     ok = exometer:update([?PFX, ?APP, node, tictacaae, ExchangeState], 1);
 do_update({tictac_aae, ExchangeType, RepairCount}) ->

--- a/src/riak_kv_stat.erl
+++ b/src/riak_kv_stat.erl
@@ -304,6 +304,10 @@ do_update(token_session_error) ->
 do_update({read_repairs, Preflist}) ->
     ok = exometer:update([?PFX, ?APP, node, gets, read_repairs], 1),
     do_repairs(Preflist);
+do_update(prompted_repairs) ->
+    ok = exometer:update([?PFX, ?APP, node, gets, prompted_repairs], 1);
+do_update(replicated_repairs) ->
+    ok = exometer:update([?PFX, ?APP, node, dets, replicated_repairs], 1);
 do_update({tictac_aae, ExchangeState}) ->
     ok = exometer:update([?PFX, ?APP, node, tictacaae, ExchangeState], 1);
 do_update({tictac_aae, ExchangeType, RepairCount}) ->
@@ -648,6 +652,18 @@ stats() ->
                                                {count, read_repairs_total}]},
      {[node, gets, skipped_read_repairs], spiral, [], [{one, skipped_read_repairs},
                                                        {count, skipped_read_repairs_total}]},
+     {
+        [node, gets, prompted_repairs],
+        spiral,
+        [],
+        [{one, prompted_repairs}, {count, prompted_repairs_total}]
+    },
+     {
+        [node, gets, replicated_repairs],
+        spiral,
+        [],
+        [{one, replicated_repairs}, {count, replicated_repairs_total}]
+    },
      {[node, tictacaae, root_compare], spiral, [],
         [{one, tictacaae_root_compare}, {count, tictacaae_root_compare_total}]},
      {[node, tictacaae, branch_compare], spiral, [],

--- a/src/riak_kv_vnode.erl
+++ b/src/riak_kv_vnode.erl
@@ -253,8 +253,8 @@
     %% Parallel AAE store rebuilds
 
 
--define(REAPER_BATCH_SIZE, 1024).
--define(ERASER_BATCH_SIZE, 1024).
+-define(REAPER_BATCH_SIZE, 128).
+-define(ERASER_BATCH_SIZE, 128).
 
 -define(INIT_REBUILD_BLOCKTIME, 1000).
 


### PR DESCRIPTION
When a tomb-stone is resurrected through replication, it will commonly prompt a clock change due to key amnesia.

After the change has been made locally, a read repair event is triggered.  this configuration option allows the repaired object to be auto-replicated.  In the case of a resurrected tombstone, it will now have an updated clock, and so will otherwise be another delta to be resolved via full-sync.

Draft PR pending riak_test