### PR TITLE
Make TreeSize in Range configurable

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -73,6 +73,7 @@ ttaaefs
 aaefold
 quickdocs
 keyname
+resync
 
 # Riak configuration terms
 cacert

--- a/docs/ReplicationGuide.md
+++ b/docs/ReplicationGuide.md
@@ -601,6 +601,36 @@ Remember the `range_check` queries will only run if either: the last check on th
 
 The aae_fold `repl_keys_range` will replicate any key within the defined range to the clusters consuming from a defined queue.  See the [AAE fold API documentation](./OtherAPI.md#aae-fold-api) for more information on using `repl_key_range`.
 
+### Re-Sync a Bucket
+
+Full-sync reconciliation is designed to be fast and efficient for confirming that clusters are in sync, but is relatively slow to resolve deltas between clusters.  The common case, when the delta is associated with a recent window of last-modified-dates (e.g. due to a recent temporary failure of replication or nodes) is optimised through the `auto_check` process; and also [re-replication](#re-replicating-keys-for-a-given-time-period) may be used to accelerate this.  However, if the delta is not restricted to a given time range of modified dates, and the delta is large, there is a need for alternative intervention to close the delta in a timely manner.
+
+For small buckets (in terms of object count), simply re-replicating the bucket could be the easiest solution, especially where it is clear the replication failure is uni-directional.  For larger buckets, and for handling bi-directional deltas, then it is possible to manually intervene to re-sync a bucket.
+
+The re-sync can be triggered from any node, from either cluster (assuming that bi-directional replication is configured).  The re-sync is cluster-wide, it is not a re-sync of data local to the node. The re-sync can handle, as with other nextgenrepl features, clusters with different configurations (e.g. `n_val` settings).
+
+A bucket re-sync will suspend the local full-sync process on the node from which it is triggered, and roll through segment slices of the bucket performing bucket-specific `range_check` operations.  As each loop covers only a single slice of the segment space, this is much quicker to repair than the standard full-sync per-bucket check, which needs to read the whole bucket space to build AAE trees for comparison.
+
+The re-sync bucket can be called via [remote_console](./OperationsAndTroubleshootingGuide.md#remote-console):
+
+```console
+riak_client:resync_bucket({<<"BucketTypeName">>, <<"BucketName">>}).
+```
+
+or, for untyped buckets.
+
+```console
+riak_client:resync_bucket(<<"BucketName">>).
+```
+
+{ .highlight }
+> In small buckets, of o(10m) keys, it would be normal to have a bucket resync operation repair deltas at a rate exceeding 1,000 per second.  
+
+As well as the helper function in `riak_client`, there is a configurable `riak_kv_ttaaefs_manager:resync_bucket/6` function exported.  For much larger buckets, this configurable version can be used to optimise the process e.g. use a smaller width (the size of the slice of the segment space), fix a specific key range or within a modified date range.
+
+{ .note }
+> It is possible to have multiple nodes running resync_bucket concurrently (to sync different buckets, or different key ranges within a bucket).  The limiting factor to horizontal scaling of resync_bucket is usually the size of [AF3 worker pool](./OtherAPI.md#node-worker-pools).  Once all workers in the pool are continuously busy, no further scaling can be achieved, without running larger pools (on all clusters).
+
 #### Participate in Coverage
 
 The full-sync comparisons between clusters are based on coverage plans - a plan which returns a set of vnode to give r=1 coverage of the whole cluster.  When a node is known not to be in a good state (perhaps following a crash), it can be rejoined to the cluster, but made ineligible for coverage plans by using the `participate_in_coverage` configuration option.

--- a/docs/ReplicationGuide.md
+++ b/docs/ReplicationGuide.md
@@ -614,10 +614,10 @@ A bucket re-sync will suspend the local full-sync process on the node from which
 The re-sync bucket can be called via [remote_console](./OperationsAndTroubleshootingGuide.md#remote-console):
 
 ```console
-riak_client:resync_bucket({<<"BucketTypeName">>, <<"BucketName">>}).
+riak_client:resync_bucket({<<"BucketType">>, <<"BucketName">>}).
 ```
 
-or, for untyped buckets.
+Or, for untyped buckets:
 
 ```console
 riak_client:resync_bucket(<<"BucketName">>).

--- a/src/riak_client.erl
+++ b/src/riak_client.erl
@@ -43,6 +43,7 @@
 -export([query/2, query_result_request/2]).
 -export([aae_fold/1, aae_fold/2]).
 -export([ttaaefs_fullsync/1, ttaaefs_fullsync/2, ttaaefs_fullsync/3]).
+-export([resync_bucket/1]).
 -export([hotbackup/4]).
 -export([stream_get_index/4,stream_get_index/3]).
 -export([set_bucket/3,get_bucket/2,reset_bucket/2]).
@@ -948,6 +949,19 @@ aae_fold(Query, {?MODULE, [Node, _ClientId]}) ->
             {error, "Invalid AAE fold definition"}
     end.
 
+
+%% @doc
+%% Resync a bucket with some sane defaults.
+-spec resync_bucket(riak_object:bucket()) -> ok.
+resync_bucket(Bucket) ->
+    riak_kv_ttaaefs_manager:resync_bucket(
+        Bucket,
+        all,
+        all,
+        128,
+        60 * 60 * 1000,
+        4
+    ).
 
 -spec ttaaefs_fullsync(riak_kv_ttaaefs_manager:work_item())
         -> ok | {error, term()}.

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -57,7 +57,6 @@
         disable_tree_repairs/0,
         disable_tree_reduction/0,
         enable_tree_reduction/0,
-        resync_bucket/1,
         resync_bucket/6
     ]
 ).
@@ -234,12 +233,6 @@ disable_tree_reduction() ->
 enable_tree_reduction() ->
     application:unset_env(riak_kv, ttaaefs_reduction).
 
-%% @doc
-%% Resync a bucket with some sane defaults.
--spec resync_bucket(riak_object:bucket()) -> ok.
-resync_bucket(Bucket) ->
-    resync_bucket(Bucket, all, all,128, 60 * 60 * 1000, 4).
-
 -spec get_current_scope() -> sync_config().
 get_current_scope() ->
     gen_server:call(?MODULE, get_current_scope, infinity).
@@ -278,6 +271,11 @@ resync_bucket(Bucket, KeyRange, DateRange, Width, Timeout, Loops) ->
             ?EXCHANGE_PAUSE_MS
         ),
     application:set_env(riak_kv, tictacaae_exchangepause, 1),
+    ?LOG_INFO(
+        "Attempt to resync bucket stared with ~w loops and ~w segment ranges",
+        [Loops, length(ShuffledSegRangeList)]
+    ),
+    SW = os:system_time(second),
     loop_resync(
         Bucket,
         KeyRange,
@@ -285,6 +283,10 @@ resync_bucket(Bucket, KeyRange, DateRange, Width, Timeout, Loops) ->
         ShuffledSegRangeList,
         Timeout,
         Loops
+    ),
+    ?LOG_INFO(
+        "Resync attempt completed in duration=~w seconds",
+        [os:system_time(second) - SW]
     ),
     enable_tree_reduction(),
     application:set_env(riak_kv, tictacaae_exchangepause, CurrentPause),
@@ -1155,8 +1157,10 @@ loop_resync(Bucket, KeyRange, DateRange, SegRangeList, Timeout, Loops) ->
             SegRangeList
         ),
     ?LOG_INFO(
-        "Full loop=~w completed with repair_count=~w with ~w ranges left",
-        [Loops, LoopRepairs, length(SegRangeList)]
+        "Full loop completed"
+        " with repair_count=~w and unfixed_ranges=~w left to resolve"
+        " with loops_remaining=~w",
+        [LoopRepairs, length(UpdRangeList), Loops - 1]
     ),
     loop_resync(Bucket, KeyRange, DateRange, UpdRangeList, Timeout, Loops - 1).
 

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -44,17 +44,23 @@
             enable_ssl/2,
             process_workitem/3]).
 
--export([set_range/4,
-            clear_range/0,
-            get_range/0,
-            autocheck_suppress/0,
-            autocheck_suppress/1,
-            maybe_repair_trees/2,
-            trigger_tree_repairs/0,
-            disable_tree_repairs/0,
-            disable_tree_reduction/0,
-            enable_tree_reduction/0
-        ]).
+-export(
+    [
+        set_range/4,
+        set_range_v2/4,
+        clear_range/0,
+        get_range/0,
+        autocheck_suppress/0,
+        autocheck_suppress/1,
+        maybe_repair_trees/2,
+        trigger_tree_repairs/0,
+        disable_tree_repairs/0,
+        disable_tree_reduction/0,
+        enable_tree_reduction/0,
+        resync_bucket/1,
+        resync_bucket/6
+    ]
+).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -139,6 +145,8 @@
 -type slot_info_fun() ::
     fun(() -> node_info()).
 -type repair_id() :: {pid(), non_neg_integer()}.
+-type sync_config() ::
+    {all, pos_integer(), pos_integer()} | {bucket, list(riak_object:bucket())}.
 
 -export_type([work_item/0, repair_id/0]).
 
@@ -191,7 +199,7 @@ set_queuename(QueueName) ->
 %% @doc
 %% Set the manager to do full sync (e.g. using cached trees).  This will leave
 %% automated sync disabled.  To re-enable the sync use resume/1
--spec set_allsync(pos_integer(), pos_integer()) -> ok.
+-spec set_allsync(pos_integer(), pos_integer()) -> {previous, sync_config()}.
 set_allsync(LocalNVal, RemoteNVal) ->
     gen_server:call(?MODULE, {set_allsync, LocalNVal, RemoteNVal}).
 
@@ -202,7 +210,7 @@ enable_ssl(Enable, Credentials) ->
 %% @doc
 %% Set the manager to sync or a list of buckets.  This will leave
 %% automated sync disabled.  To re-enable the sync use resume/1
--spec set_bucketsync(list(riak_object:bucket())) -> ok.
+-spec set_bucketsync(list(riak_object:bucket())) -> {previous, sync_config()}.
 set_bucketsync(BucketList) ->
     gen_server:call(?MODULE, {set_bucketsync, BucketList}).
 
@@ -224,6 +232,54 @@ disable_tree_reduction() ->
 enable_tree_reduction() ->
     application:unset_env(riak_kv, ttaaefs_reduction).
 
+%% @doc
+%% Resync a bucket with some sane defaults.
+-spec resync_bucket(riak_object:bucket()) -> ok.
+resync_bucket(Bucket) ->
+    resync_bucket(Bucket, all, all,128, 60 * 60 * 1000, 4).
+
+%% @doc
+%% Resync an out-of sync bucket, a Width of the segment space at a time.  The
+%% Width should be between 1 and 2048 (higher numbers that that will lose 
+%% efficiency), lower numbers are less likely to error due to timeout.  Width
+%% should be a factor of 2.
+-spec resync_bucket(
+    riak_object:bucket(),
+    {riak_object:key(), riak_object:key()} | all,
+    {calendar:datetime(), calendar:datetime()} | all,
+    1..2048,
+        % The lower the number the faster each query.
+        % Should be at least max_results, reduces the scope of each
+        % query in a loop
+    pos_integer(),
+        % Timeout for an individual sync attempt within the loop
+    pos_integer()
+        % how many times to loop, to complete sync if all segments are
+        % mismatched will need to be at least:
+        % Width div (MaxResults * RangeBoost)
+) ->
+    ok.
+resync_bucket(Bucket, KeyRange, DateRange, Width, Timeout, Loops) ->
+    ShuffledSegRangeList = shuffle(generate_seg_lists(Width)),
+    pause(),
+    {previous, SyncConfig} = set_bucketsync([Bucket]),
+    disable_tree_reduction(),
+    loop_resync(
+        Bucket,
+        KeyRange,
+        DateRange,
+        ShuffledSegRangeList,
+        Timeout,
+        Loops
+    ),
+    enable_tree_reduction(),
+    case SyncConfig of
+        {all, LocalNVal, RemoteNVal} ->
+            set_allsync(LocalNVal, RemoteNVal);
+        {bucket, BucketList} ->
+            set_bucketsync(BucketList)
+    end,
+    ok.
 
 
 %%%============================================================================
@@ -404,11 +460,27 @@ handle_call({set_sink, Protocol, PeerIP, PeerPort}, _From, State) ->
 handle_call({set_queuename, QueueName}, _From, State) ->
     {reply, ok, State#state{queue_name = QueueName}};
 handle_call({set_allsync, LocalNVal, RemoteNVal}, _From, State) ->
+    Reply =
+        case State#state.scope of
+            all ->
+                {
+                    previous,
+                    {all, State#state.local_nval, State#state.remote_nval}
+                };
+            bucket ->
+                {
+                    previous,
+                    {bucket, State#state.bucket_list}
+                }
+        end,
     {reply,
-        ok,
-        State#state{scope = all,
-                    local_nval = LocalNVal,
-                    remote_nval = RemoteNVal}};
+        Reply,
+        State#state{
+            scope = all,
+            local_nval = LocalNVal,
+            remote_nval = RemoteNVal
+        }
+    };
 handle_call({enable_ssl, Enable, Credentials}, _From, State) ->
     case Enable of
         true ->
@@ -417,10 +489,26 @@ handle_call({enable_ssl, Enable, Credentials}, _From, State) ->
             {reply, ok, State#state{ssl_credentials = undefined}}
     end;
 handle_call({set_bucketsync, BucketList}, _From, State) ->
+    Reply =
+        case State#state.scope of
+            all ->
+                {
+                    previous,
+                    {all, State#state.local_nval, State#state.remote_nval}
+                };
+            bucket ->
+                {
+                    previous,
+                    {bucket, State#state.bucket_list}
+                }
+        end,
     {reply,
-        ok,
-        State#state{scope = bucket,
-                    bucket_list = BucketList}}.
+        Reply,
+        State#state{
+            scope = bucket,
+            bucket_list = BucketList
+        }
+    }.
 
 handle_cast({reply_complete, ReqID, Result}, State) ->
     LastExchangeStart = State#state.last_exchange_start,
@@ -579,10 +667,12 @@ handle_cast({range_check, ReqID, From, _Now}, State) ->
                         % and the low time of the next
                         {MegaSecs, Secs, _MicroSecs} = os:timestamp(),
                         NowSecs = MegaSecs * ?MEGA  + Secs + 5,
-                        {all,
+                        {
+                            all,
                             all,
                             PrevMega * ?MEGA + PrevSecs,
-                            NowSecs}
+                            NowSecs
+                        }
                 end;
             SetRange ->
                 SetRange
@@ -596,23 +686,32 @@ handle_cast({range_check, ReqID, From, _Now}, State) ->
                     From ! {ReqID, {range_check, 0}}
             end,
             {noreply, State, ?LOOP_TIMEOUT};
-        {Bucket, KeyRange, LowerTime, UpperTime} ->
+        {Bucket, KeyRange, LMDRange, SegFilter} ->
             clear_range(),
             case State#state.scope of
                 all ->
                     Filter =
-                        {filter, Bucket, all, large, all,
-                        {LowerTime, UpperTime}, pre_hash},
+                        {
+                            filter,
+                            Bucket,
+                            all,
+                            large,
+                            all,
+                            LMDRange,
+                            pre_hash
+                        },
                     {State0, Timeout} =
-                        sync_clusters(From,
-                                        ReqID,
-                                        State#state.local_nval,
-                                        State#state.remote_nval,
-                                        Filter,
-                                        undefined, 
-                                        full,
-                                        State,
-                                        range_check),
+                        sync_clusters(
+                            From,
+                            ReqID,
+                            State#state.local_nval,
+                            State#state.remote_nval,
+                            Filter,
+                            undefined, 
+                            full,
+                            State,
+                            range_check
+                        ),
                     {noreply, State0, Timeout};
                 bucket ->
                     {B, NextBucketList} =
@@ -629,14 +728,22 @@ handle_cast({range_check, ReqID, From, _Now}, State) ->
                             B,
                             KeyRange,
                             get_range_treesize(),
-                            all,
-                            {LowerTime, UpperTime},
+                            SegFilter,
+                            LMDRange,
                             pre_hash
                         },
                     {State0, Timeout} =
-                        sync_clusters(From, ReqID, range, range, Filter,
-                                        NextBucketList, partial, State,
-                                        range_check),
+                        sync_clusters(
+                            From,
+                            ReqID,
+                            range,
+                            range,
+                            Filter,
+                            NextBucketList,
+                            partial,
+                            State,
+                            range_check
+                        ),
                     {noreply, State0, Timeout}
             end
     end;
@@ -665,7 +772,7 @@ handle_cast({auto_check, ReqID, From, Now}, State) ->
             % Whenever there is a range defined of the last check was
             % successful, a range check is the optimal way of proceeding
             ?LOG_INFO(
-                "Auto check prompts range_check reqid=~w due to clause ~p",
+                "Auto check prompts range_check reqid=~w due to clause ~0p",
                 [ReqID, Clause]),
             process_workitem(range_check, ReqID, From, Now)
     end,
@@ -741,24 +848,95 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Environment state management functions
 %%%============================================================================
 
-%% @doc
-%% Set a specific range to be the target for subsequent range_check queries
--spec set_range(riak_object:bucket()|all,
-                        {riak_object:key(), riak_object:key()}|all,
-                        calendar:datetime(),
-                        calendar:datetime())
-                    -> ok.
-set_range(Bucket, KeyRange, LowDate, HighDate) ->
-    EpochTime =
-        calendar:datetime_to_gregorian_seconds({{1970,1,1},{0,0,0}}),
-    LowTS = 
-        calendar:datetime_to_gregorian_seconds(LowDate) - EpochTime,
-    HighTS =
-        calendar:datetime_to_gregorian_seconds(HighDate) - EpochTime,
-    true = HighTS >= LowTS,
-    true = LowTS > 0,
-    application:set_env(riak_kv, ttaaefs_check_range,
-                        {Bucket, KeyRange, LowTS - 1, HighTS + 1}).
+%% @doc Legacy set_range API ... some operators may have scripts that should
+%% not break
+-spec set_range(
+    riak_object:bucket()|all,
+    {riak_object:key(), riak_object:key()}|all,
+    calendar:datetime(),
+    calendar:datetime()
+) ->
+    ok.
+set_range(Bucket, KeyRange, LowDateTime, HighDateTime) ->
+    set_range_v2(Bucket, KeyRange, {LowDateTime, HighDateTime}, all).
+
+-type tree_size() :: small|medium|large|xlarge.
+    % Only tree sizes which are compatible with segment acceleration are
+    % supported.  Sizes < 2 ^ 15 are not supported.
+
+%% @doc Set a specific range to be the target for subsequent range_check
+%% queries. A segment range can be used in scripts for resolving bucket sync
+%% issues, where that bucket cannot be readily broken into key ranges.  A
+%% segment range will reduce the cost of the merge_tree_range query used to
+%% find segments that will then be fixed.  A {tree_compare, 0} means that
+%% The tree is fixed for just this segment range - and my be broken for other
+%% ranges.
+-spec set_range_v2(
+    riak_object:bucket()|all,
+    {riak_object:key(), riak_object:key()} | all,
+    {calendar:datetime(), calendar:datetime()} | all,
+    {tree_size(), non_neg_integer(), non_neg_integer()}
+        | {tree_size(), list(non_neg_integer())}
+        | all
+) -> 
+    ok.
+set_range_v2(Bucket, KeyRange, DateRange, SegmentRange) ->
+    UsableDateRange =
+        case DateRange of
+            all ->
+                all;
+            {LowDate, HighDate} ->
+                EpochTime =
+                    calendar:datetime_to_gregorian_seconds(
+                        {{1970, 1, 1}, {0, 0, 0}}
+                    ),
+                LowTS = 
+                    calendar:datetime_to_gregorian_seconds(LowDate)
+                    - EpochTime,
+                HighTS =
+                    calendar:datetime_to_gregorian_seconds(HighDate)
+                    - EpochTime,
+                true = HighTS >= LowTS,
+                true = LowTS > 0,
+                {LowTS, HighTS}
+        end,
+    SegmentFilter =
+        case SegmentRange of
+            all ->
+                all;
+            {TreeSize, LowSeg, HighSeg}
+                when
+                    is_integer(LowSeg),
+                    is_integer(HighSeg),
+                    LowSeg >= 0,
+                    HighSeg >= 0,
+                    LowSeg =< HighSeg ->
+                MaxSeg =
+                    case TreeSize of
+                        small ->
+                            256 * 256;
+                        medium ->
+                            1024 * 256;
+                        large ->
+                            4096 * 256;
+                        xlarge ->
+                            16384 * 256
+                    end,
+                true = HighSeg < MaxSeg,
+                {segments, lists:seq(LowSeg, HighSeg), TreeSize};
+            {TreeSize, IntList} when is_list(IntList) ->
+                {segments, IntList, TreeSize} 
+        end,
+    application:set_env(
+        riak_kv,
+        ttaaefs_check_range,
+        {
+            Bucket,
+            KeyRange,
+            UsableDateRange,
+            SegmentFilter
+        }
+    ).
 
 -spec clear_range() -> ok.
 clear_range() ->
@@ -887,6 +1065,92 @@ maybe_repair_trees(LastRepairID, _Filtered) ->
 %%%============================================================================
 %%% Internal functions
 %%%============================================================================
+
+%% @doc
+%% Generate an efficient segment list with W segments per member of the list.
+%% The segment acceleration looks at the first 15 bits of the segment only, but
+%% a small tree has 16 bit segments - so each list should minimise the number
+%% of segment matches by coupling the segments when the first bit (of 16) is
+%% 0 and 1
+generate_seg_lists(1) ->
+    lists:map(fun(S) -> [S] end, lists:seq(0, 16#FFFF));
+generate_seg_lists(W) when W > 1 ->
+    HalfW = W div 2,
+    lists:map(
+        fun(I) -> 
+            lists:seq(I, I + HalfW - 1)
+            ++ lists:seq(I + 16#8000, I + 16#8000 + HalfW - 1)
+        end,
+        lists:seq(0, 16#7FFF, HalfW)
+    ).
+
+%% @doc
+%% Shuffle a list, inefficiently and inaccuratly.  Can do better when shuffle
+%% function is introduced and OTP.  The inefficiency and inaccuracy are
+%% irrelevant in this use case.
+shuffle(L) ->
+    RandRange = length(L) * 2,
+    lists:map(
+        fun({_R, SE}) -> SE end,
+        lists:keysort(
+            1,
+            lists:map(fun(E) -> {rand:uniform(RandRange), E} end, L)
+        )
+    ).
+
+%% @doc
+%% Loop ove a list of segments Loops times.  If a segment shows as being
+%% in-sync, drop it from future loops.
+loop_resync(_Bucket, _KeyRange, _DateRange, SegRangeList, _Timeout, 0) ->
+    ?LOG_INFO(
+        "All loops complete with ~w ranges unfixed",
+        [length(SegRangeList)]
+    ),
+    ok;
+loop_resync(Bucket, KeyRange, DateRange, SegRangeList, Timeout, Loops) ->
+    {UpdRangeList, LoopRepairs} =
+        lists:foldl(
+            fun(SegRange, {NextLoopAcc, TotalRepairs}) ->
+                ok =
+                    riak_kv_ttaaefs_manager:set_range_v2(
+                        Bucket,
+                        KeyRange,
+                        DateRange,
+                        {small, SegRange}
+                    ),
+                ReqID = erlang:phash2({self(), os:timestamp()}),
+                process_workitem(range_check, ReqID, os:timestamp()),
+                receive
+                    {ReqID, {clock_compare, N}} ->
+                        {[SegRange | NextLoopAcc], TotalRepairs + N};
+                    {ReqID, {tree_compare, 0}} ->
+                        ?LOG_INFO(
+                            "Single segment range complete in resync_bucket"
+                        ),
+                        {NextLoopAcc, TotalRepairs};
+                    {ReqID, Error} ->
+                        ?LOG_WARNING(
+                            "Unexpected result in resync_bucket ~0p",
+                            Error
+                        ),
+                        {[SegRange | NextLoopAcc], TotalRepairs}
+                after
+                    Timeout ->
+                        ?LOG_WARNING(
+                            "loop_resync has timeout ~w exceeeded",
+                            Timeout
+                        ),
+                        {NextLoopAcc, TotalRepairs}
+                end
+            end,
+            {[], 0},
+            SegRangeList
+        ),
+    ?LOG_INFO(
+        "Full loop=~w completed with repair_count=~w with ~w ranges left",
+        [Loops, LoopRepairs, length(SegRangeList)]
+    ),
+    loop_resync(Bucket, KeyRange, DateRange, UpdRangeList, Timeout, Loops - 1).
 
 %% @doc
 %% Sync two clusters - return an updated loop state and a timeout
@@ -1802,5 +2066,53 @@ schedule_seconds_test() ->
         schedule_seconds(2, SliceNumber, 2, NodeCount, SliceCount),
     ?assertEqual(1500, SecsFromStartTime2).
 
+seglist_test() ->
+    CheckAllSegments =
+        fun(SL) ->
+            SFSL = lists:sort(lists:flatten(SL)),
+            Expected = lists:seq(0, 16#FFFF),
+            ?assertMatch(Expected, SFSL)
+        end,
+    LengthCheck =
+        fun(SL, ExpectedL) ->
+            ?assert(
+                lists:all(
+                    fun(SSL) -> length(SSL) == ExpectedL end,
+                    SL
+                )
+            )
+        end,
+    AlignmentCheck =
+        fun(SL, ExpectedL) ->
+            ?assert(
+                lists:all(
+                    fun(SSL) ->
+                        FL =
+                            lists:usort(
+                                lists:map(
+                                    fun(S) -> S band 16#7FFF end,
+                                    SSL
+                                )
+                            ),
+                        length(FL) == (ExpectedL div 2)
+                    end,
+                    SL
+                )
+            )
+        end,
+    SL1 = generate_seg_lists(1),
+    CheckAllSegments(SL1),
+    ?assertMatch(65536, length(SL1)),
+    LengthCheck(SL1, 1),
+    SL2 = generate_seg_lists(2),
+    CheckAllSegments(SL2),
+    ?assertMatch(32768, length(SL2)),
+    LengthCheck(SL2, 2),
+    AlignmentCheck(SL2, 2),
+    SL8 = generate_seg_lists(8),
+    CheckAllSegments(SL8),
+    ?assertMatch(8192, length(SL8)),
+    LengthCheck(SL8, 8),
+    AlignmentCheck(SL8, 8).
 
 -endif.

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -271,6 +271,13 @@ resync_bucket(Bucket, KeyRange, DateRange, Width, Timeout, Loops) ->
     SyncConfig = get_current_scope(), 
     set_bucketsync([Bucket]),
     disable_tree_reduction(),
+    CurrentPause =
+        application:get_env(
+            riak_kv,
+            tictacaae_exchangepause,
+            ?EXCHANGE_PAUSE_MS
+        ),
+    application:set_env(riak_kv, tictacaae_exchangepause, 1),
     loop_resync(
         Bucket,
         KeyRange,
@@ -280,6 +287,7 @@ resync_bucket(Bucket, KeyRange, DateRange, Width, Timeout, Loops) ->
         Loops
     ),
     enable_tree_reduction(),
+    application:set_env(riak_kv, tictacaae_exchangepause, CurrentPause),
     case SyncConfig of
         {all, LocalNVal, RemoteNVal} ->
             set_allsync(LocalNVal, RemoteNVal);
@@ -977,19 +985,20 @@ get_exchange_options(MaxResults, WorkType, KeyFilter) ->
             {max_results, MaxResults},
             {scan_timeout, ?CRASH_TIMEOUT div 2},
             {purpose, WorkType},
+            {log_levels, riak_kv_tictacaae_repairs:aae_loglevels()},
             {key_filter, KeyFilter}
         ],
     WRF =
         case application:get_env(riak_kv, ttaaefs_reduction) of
             {ok, Scale} when is_float(Scale), Scale >= 0.0, Scale =< 1.0 ->
-                [{worthwile_reduction, Scale}];
+                [{worthwhile_reduction, Scale}];
             _ ->
                 []
         end,
     WRC =
         case application:get_env(riak_kv, ttaaefs_reduction_cached) of
             {ok, Count} when is_integer(Count), Count >= 0 ->
-                [{worthwile_reduction_cached, Count}];
+                [{worthwhile_reduction_cached, Count}];
             _ ->
                 []
         end,
@@ -1111,7 +1120,7 @@ loop_resync(Bucket, KeyRange, DateRange, SegRangeList, Timeout, Loops) ->
         lists:foldl(
             fun(SegRange, {NextLoopAcc, TotalRepairs}) ->
                 ok =
-                    riak_kv_ttaaefs_manager:set_range_v2(
+                    set_range_v2(
                         Bucket,
                         KeyRange,
                         DateRange,
@@ -1123,7 +1132,7 @@ loop_resync(Bucket, KeyRange, DateRange, SegRangeList, Timeout, Loops) ->
                     {ReqID, {clock_compare, N}} ->
                         {[SegRange | NextLoopAcc], TotalRepairs + N};
                     {ReqID, {tree_compare, 0}} ->
-                        ?LOG_INFO(
+                        ?LOG_DEBUG(
                             "Single segment range complete in resync_bucket"
                         ),
                         {NextLoopAcc, TotalRepairs};
@@ -1204,7 +1213,8 @@ sync_clusters(From, ReqID, LNVal, RNVal, Filter, NextBucketList,
                 fun(RepairList) ->
                     riak_kv_replrtq_src:replrtq_ttaaefs(
                         State#state.queue_name,
-                        RepairList),
+                        RepairList
+                    ),
                     RepairList
                 end,
             RemoteRepairFun =

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -146,7 +146,9 @@
     fun(() -> node_info()).
 -type repair_id() :: {pid(), non_neg_integer()}.
 -type sync_config() ::
-    {all, pos_integer(), pos_integer()} | {bucket, list(riak_object:bucket())}.
+    {all, pos_integer(), pos_integer()}
+    | {bucket, list(riak_object:bucket())}
+    | disabled.
 
 -export_type([work_item/0, repair_id/0]).
 
@@ -199,7 +201,7 @@ set_queuename(QueueName) ->
 %% @doc
 %% Set the manager to do full sync (e.g. using cached trees).  This will leave
 %% automated sync disabled.  To re-enable the sync use resume/1
--spec set_allsync(pos_integer(), pos_integer()) -> {previous, sync_config()}.
+-spec set_allsync(pos_integer(), pos_integer()) -> ok.
 set_allsync(LocalNVal, RemoteNVal) ->
     gen_server:call(?MODULE, {set_allsync, LocalNVal, RemoteNVal}).
 
@@ -210,7 +212,7 @@ enable_ssl(Enable, Credentials) ->
 %% @doc
 %% Set the manager to sync or a list of buckets.  This will leave
 %% automated sync disabled.  To re-enable the sync use resume/1
--spec set_bucketsync(list(riak_object:bucket())) -> {previous, sync_config()}.
+-spec set_bucketsync(list(riak_object:bucket())) -> ok.
 set_bucketsync(BucketList) ->
     gen_server:call(?MODULE, {set_bucketsync, BucketList}).
 
@@ -238,6 +240,10 @@ enable_tree_reduction() ->
 resync_bucket(Bucket) ->
     resync_bucket(Bucket, all, all,128, 60 * 60 * 1000, 4).
 
+-spec get_current_scope() -> sync_config().
+get_current_scope() ->
+    gen_server:call(?MODULE, get_current_scope, infinity).
+
 %% @doc
 %% Resync an out-of sync bucket, a Width of the segment space at a time.  The
 %% Width should be between 1 and 2048 (higher numbers that that will lose 
@@ -262,7 +268,8 @@ resync_bucket(Bucket) ->
 resync_bucket(Bucket, KeyRange, DateRange, Width, Timeout, Loops) ->
     ShuffledSegRangeList = shuffle(generate_seg_lists(Width)),
     pause(),
-    {previous, SyncConfig} = set_bucketsync([Bucket]),
+    SyncConfig = get_current_scope(), 
+    set_bucketsync([Bucket]),
     disable_tree_reduction(),
     loop_resync(
         Bucket,
@@ -277,7 +284,9 @@ resync_bucket(Bucket, KeyRange, DateRange, Width, Timeout, Loops) ->
         {all, LocalNVal, RemoteNVal} ->
             set_allsync(LocalNVal, RemoteNVal);
         {bucket, BucketList} ->
-            set_bucketsync(BucketList)
+            set_bucketsync(BucketList);
+        disabled ->
+            ?LOG_WARNING("Scope left enabled by resync_bucket script")
     end,
     ok.
 
@@ -460,21 +469,8 @@ handle_call({set_sink, Protocol, PeerIP, PeerPort}, _From, State) ->
 handle_call({set_queuename, QueueName}, _From, State) ->
     {reply, ok, State#state{queue_name = QueueName}};
 handle_call({set_allsync, LocalNVal, RemoteNVal}, _From, State) ->
-    Reply =
-        case State#state.scope of
-            all ->
-                {
-                    previous,
-                    {all, State#state.local_nval, State#state.remote_nval}
-                };
-            bucket ->
-                {
-                    previous,
-                    {bucket, State#state.bucket_list}
-                }
-        end,
     {reply,
-        Reply,
+        ok,
         State#state{
             scope = all,
             local_nval = LocalNVal,
@@ -489,26 +485,24 @@ handle_call({enable_ssl, Enable, Credentials}, _From, State) ->
             {reply, ok, State#state{ssl_credentials = undefined}}
     end;
 handle_call({set_bucketsync, BucketList}, _From, State) ->
-    Reply =
-        case State#state.scope of
-            all ->
-                {
-                    previous,
-                    {all, State#state.local_nval, State#state.remote_nval}
-                };
-            bucket ->
-                {
-                    previous,
-                    {bucket, State#state.bucket_list}
-                }
-        end,
     {reply,
-        Reply,
+        ok,
         State#state{
             scope = bucket,
             bucket_list = BucketList
         }
-    }.
+    };
+handle_call(get_current_scope, _From, State) ->
+    Reply =
+        case State#state.scope of
+            all ->
+                {all, State#state.local_nval, State#state.remote_nval};
+            bucket ->
+                {bucket, State#state.bucket_list};
+            disabled ->
+                disabled
+        end,
+    {reply, Reply, State}.
 
 handle_cast({reply_complete, ReqID, Result}, State) ->
     LastExchangeStart = State#state.last_exchange_start,
@@ -670,8 +664,8 @@ handle_cast({range_check, ReqID, From, _Now}, State) ->
                         {
                             all,
                             all,
-                            PrevMega * ?MEGA + PrevSecs,
-                            NowSecs
+                            {PrevMega * ?MEGA + PrevSecs, NowSecs},
+                            all
                         }
                 end;
             SetRange ->
@@ -943,9 +937,14 @@ clear_range() ->
     application:set_env(riak_kv, ttaaefs_check_range, none).
 
 -spec get_range() ->
-        none|{riak_object:bucket()|all, 
-                {riak_object:key(), riak_object:key()}|all,
-                pos_integer(), pos_integer()}.
+        none
+        |
+            {
+                riak_object:bucket() | all, 
+                {riak_object:key(), riak_object:key()} | all,
+                {pos_integer(), pos_integer()} | all,
+                {segments, list(non_neg_integer()), tree_size()} | all
+            }.
 get_range() ->
     application:get_env(riak_kv, ttaaefs_check_range, none).
 

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -51,7 +51,9 @@
             autocheck_suppress/1,
             maybe_repair_trees/2,
             trigger_tree_repairs/0,
-            disable_tree_repairs/0
+            disable_tree_repairs/0,
+            disable_tree_reduction/0,
+            enable_tree_reduction/0
         ]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -203,6 +205,25 @@ enable_ssl(Enable, Credentials) ->
 -spec set_bucketsync(list(riak_object:bucket())) -> ok.
 set_bucketsync(BucketList) ->
     gen_server:call(?MODULE, {set_bucketsync, BucketList}).
+
+%% @doc
+%% When performing per-bucket merges, the reduction check can be disabled with
+%% this function.  If the range being covered is static (i.e. no mutating 
+%% objects are covered, a needless verification of merge_tree_range can be
+%% avoided with this option).
+%% 
+%% This is a runtime change only, it cannot be permanently enabled across
+%% restarts.
+-spec disable_tree_reduction() -> ok.
+disable_tree_reduction() ->
+    application:set_env(riak_kv, ttaaefs_reduction, 1.0).
+
+%% @doc
+%% Reverse the disabling of tree reduction
+-spec enable_tree_reduction() -> ok.
+enable_tree_reduction() ->
+    application:unset_env(riak_kv, ttaaefs_reduction).
+
 
 
 %%%============================================================================
@@ -602,15 +623,16 @@ handle_cast({range_check, ReqID, From, _Now}, State) ->
                             Bucket ->
                                 {Bucket, State#state.bucket_list}
                         end,
-                    TreeSize =
-                        application:get_env(
-                            riak_kv,
-                            ttaaefs_range_tree_size,
-                            small
-                        ),
                     Filter =
-                        {filter, B, KeyRange, TreeSize, all,
-                        {LowerTime, UpperTime}, pre_hash},
+                        {
+                            filter,
+                            B,
+                            KeyRange,
+                            get_range_treesize(),
+                            all,
+                            {LowerTime, UpperTime},
+                            pre_hash
+                        },
                     {State0, Timeout} =
                         sync_clusters(From, ReqID, range, range, Filter,
                                         NextBucketList, partial, State,
@@ -749,6 +771,52 @@ clear_range() ->
 get_range() ->
     application:get_env(riak_kv, ttaaefs_check_range, none).
 
+-spec get_range_treesize() -> small|medium|large|xlarge.
+%% Get Configured tree range size.  Tree sizes smaller than small are not
+%% supported as a segment space =< 2 ^ 15 is not compatible with segment
+%% acceleration of folds
+get_range_treesize() ->
+    case application:get_env(riak_kv, ttaaefs_range_tree_size) of
+        {ok, Size} when
+            Size == small;
+            Size == medium;
+            Size == large;
+            Size == xlarge ->
+            Size;
+        _ ->
+            small
+    end.
+
+get_exchange_options(MaxResults, WorkType, KeyFilter) ->
+    ExchangePause =
+        application:get_env(
+            riak_kv,
+            tictacaae_exchangepause,
+            ?EXCHANGE_PAUSE_MS
+        ),
+    InitOpts =
+        [
+            {transition_pause_ms, ExchangePause},
+            {max_results, MaxResults},
+            {scan_timeout, ?CRASH_TIMEOUT div 2},
+            {purpose, WorkType},
+            {key_filter, KeyFilter}
+        ],
+    WRF =
+        case application:get_env(riak_kv, ttaaefs_reduction) of
+            {ok, Scale} when is_float(Scale), Scale >= 0.0, Scale =< 1.0 ->
+                [{worthwile_reduction, Scale}];
+            _ ->
+                []
+        end,
+    WRC =
+        case application:get_env(riak_kv, ttaaefs_reduction_cached) of
+            {ok, Count} when is_integer(Count), Count >= 0 ->
+                [{worthwile_reduction_cached, Count}];
+            _ ->
+                []
+        end,
+    WRF ++ WRC ++ InitOpts.
 
 -spec autocheck_suppress() -> ok.
 autocheck_suppress() ->
@@ -919,9 +987,6 @@ sync_clusters(From, ReqID, LNVal, RNVal, Filter, NextBucketList,
                     MaxResults,
                     {ReqID0, Ref, WorkType}),
 
-            ExchangePause =
-                app_helper:get_env(
-                    riak_kv, tictacaae_exchangepause, ?EXCHANGE_PAUSE_MS),
             {ok, ExPid, ExID} =
                 aae_exchange:start(
                     Ref,
@@ -930,13 +995,7 @@ sync_clusters(From, ReqID, LNVal, RNVal, Filter, NextBucketList,
                     RepairFun,
                     ReplyFun,
                     Filter, 
-                    [
-                        {transition_pause_ms, ExchangePause},
-                        {max_results, MaxResults},
-                        {scan_timeout, ?CRASH_TIMEOUT div 2},
-                        {purpose, WorkType},
-                        {key_filter, KeyFilter}
-                    ]
+                    get_exchange_options(MaxResults, WorkType, KeyFilter)
                 ),
             
             ?LOG_INFO(

--- a/src/riak_kv_ttaaefs_manager.erl
+++ b/src/riak_kv_ttaaefs_manager.erl
@@ -602,8 +602,14 @@ handle_cast({range_check, ReqID, From, _Now}, State) ->
                             Bucket ->
                                 {Bucket, State#state.bucket_list}
                         end,
+                    TreeSize =
+                        application:get_env(
+                            riak_kv,
+                            ttaaefs_range_tree_size,
+                            small
+                        ),
                     Filter =
-                        {filter, B, KeyRange, small, all,
+                        {filter, B, KeyRange, TreeSize, all,
                         {LowerTime, UpperTime}, pre_hash},
                     {State0, Timeout} =
                         sync_clusters(From, ReqID, range, range, Filter,


### PR DESCRIPTION
A larger tree size will be slower in merging the trees, but will allow a more granular view of keys/clocks.

As well as making the key size configurable, a helper function to resync a bucket is added.  This will resync using a loop of individual exchanges, but breaking up the key-space using segment filters.  This, in testing, is a fast way to resync an individual bucket - handling the situation when the delta space is o(tree-size) much better than leaving full-sync to slowly work through.

The helper function uses some sane defaults, but the underlying function allows for a flexible configurable approach.

This is based on some scripting done for a large Riak user that had a o(1bn) delta in a o(10bn) size bucket after some  failed operational actions.  In this case KeySpace ranges were used, but for buckets of smaller sizes this should be unnecessary - the use of segment space should be sufficient.