### PR TITLE
validate data type in `riak admin bucket-type create`

### DIFF
--- a/src/riak_kv_console.erl
+++ b/src/riak_kv_console.erl
@@ -56,6 +56,8 @@
          aae_repair_status/1,
          aae_tree_status/1]).
 
+-include("riak_kv_types.hrl").  %% for MOD_MAP
+-include("riak_kv_wm_raw.hrl").  %% for ?JSON_DATATYPE
 -include_lib("kernel/include/logger.hrl").
 
 
@@ -533,10 +535,19 @@ bucket_type_create([TypeStr, PropsStr]) ->
     bucket_type_create(Type, catch mochijson2:decode(PropsStr)).
 
 bucket_type_create(Type, {struct, Fields}) ->
+    ExistingDatatypes = [atom_to_binary(A) || {A, _} <- ?MOD_MAP],
     case proplists:get_value(<<"props">>, Fields) of
         {struct, Props} ->
-            ErlProps = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props],
-            bucket_type_print_create_result(Type, riak_core_bucket_type:create(Type, ErlProps));
+            case lists:member(
+                   proplists:get_value(?JSON_DATATYPE, Props), ExistingDatatypes) of
+                true ->
+                    ErlProps = [riak_kv_wm_utils:erlify_bucket_prop(P) || P <- Props],
+                    bucket_type_print_create_result(
+                      Type, riak_core_bucket_type:create(Type, ErlProps));
+                false ->
+                    io:format("Cannot create bucket type ~ts: invalid data type~n", [Type]),
+                    error
+            end;
         _ ->
             io:format("Cannot create bucket type ~ts: no props field found in json~n", [Type]),
             error


### PR DESCRIPTION
A fix for https://github.com/basho/riak_core/issues/950 and https://github.com/OpenRiak/riak_kv/issues/17.