### PR TITLE
When creating a (fake) new actor epoch entry - keep LMD unmodified

### DIFF
--- a/src/riak_object.erl
+++ b/src/riak_object.erl
@@ -1064,7 +1064,11 @@ set_vclock(Object=#r_object{}, VClock) -> Object#r_object{vclock=VClock}.
 %% write showed local amnesia
 -spec new_actor_epoch(riak_object(), vclock:vclock_node()) -> riak_object().
 new_actor_epoch(Object=#r_object{vclock=VC}, ClientId) ->
-    NewClock = vclock:increment(ClientId, VC),
+    % This converts to and back needlessly, but amnesia is an irregular
+    % scenario, so not in the critical path for performance optimisations
+    LMD = vclock:last_modified(VC),
+    TS = calendar:datetime_to_gregorian_seconds(LMD),
+    NewClock = vclock:increment(ClientId, TS, VC),
     Object#r_object{vclock=NewClock}.
 
 %% @doc  Increment the entry for ClientId in O's vclock.
@@ -2177,9 +2181,22 @@ bucket_prop_needers_test_() ->
             fun find_bestobject_headget_confusion_reconcile/0},
         {"Test Summary Bin Extract", fun summary_binary_extract/0},
         {"Next Gen Repl Encode/Decode", fun nextgenrepl/0},
-        {"Simple Head/Get merge", fun simple_merge_head_and_get/0}
+        {"Simple Head/Get merge", fun simple_merge_head_and_get/0},
+        {"Confirm new actor epoch does not advance LMD", fun new_actor_epoch_lmd/0}
     ]
     }.
+
+new_actor_epoch_lmd() ->
+    {_O,O2} = update_test(),
+    LMD2 = vclock:last_modified(vclock(O2)),
+    timer:sleep(1001),
+    O3 = riak_object:increment_vclock(O2, self()),
+    timer:sleep(1001),
+    LMD3 = vclock:last_modified(vclock(O3)),
+    O4 = new_actor_epoch(O3, fake_actor),
+    LMD4 = vclock:last_modified(vclock(O4)),
+    ?assert(LMD3 > LMD2),
+    ?assert(LMD4 == LMD3).
 
 ancestor() ->
     Actor = self(),


### PR DESCRIPTION
A new actor epoch change is only made on an uncoordinated PUT, so it does not alter the object Last-Modified-Date - and likewise it should not alter the assumed LMD from the vector clock.

Looking at the comments on riak_kv_vnode:maybe_new_actor_epoch/2 - this update is only so that a new "frontier event" is created the next time this object is coordinated on the vnode.  The timestamp is irrelevant:

https://github.com/OpenRiak/riak_kv/blob/abcfdb761fa113348429281b59e97038b5b2dcce/src/riak_kv_vnode.erl#L4777-L4786